### PR TITLE
Update iso2flux.xml

### DIFF
--- a/tools/phenomenal/fluxomics/iso2flux/iso2flux.xml
+++ b/tools/phenomenal/fluxomics/iso2flux/iso2flux.xml
@@ -22,8 +22,7 @@ run_iso2flux.py -e "$tracing_data"
 -c "$constraints"
 #end if
 
--t "$incubation_time"
--f "$experimental_factor"
+
 
 #if str( $confidence.compute ) == "no":
 -q
@@ -38,8 +37,6 @@ run_iso2flux.py -e "$tracing_data"
     <param type="data" name="sbml_model" format="xml"/>
     <param type="data" name="parameters" format="csv" optional="True"/>
     <param type="data" name="constraints" format="csv" optional="True"/>
-    <param type="float" name="incubation_time" value="1"/>
-    <param type="text" name="experimental_factor" value="Factor"/>
     <conditional name="confidence">
         <param name="compute" label="Compute confidence intervals" type="select">
             <option value="yes">Yes</option>


### PR DESCRIPTION
Incubation_time and experimental_factor are no longer used by Iso2flux, they should be removed to prevent confusion.
Iso2flux now generates best_label and best_fluxes as output so the output section is fine as it is