### PR TITLE
Fluxomics stationary workflow and tools cv0.2.x series

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -54,18 +54,18 @@
             <param id="docker_enabled">true</param>
         </destination>
         <destination id="iso2flux-container" runner="k8s">
-            <param id="docker_repo_override">docker-registry.phenomenal-h2020.eu</param>
+            <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
             <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">iso2flux</param>
-            <param id="docker_tag_override">latest</param>
+            <param id="docker_tag_override">dev_v0.2_cv0.2.23</param>
             <param id="max_pod_retrials">1</param>
             <param id="docker_enabled">true</param>
         </destination>
         <destination id="midcor-container" runner="k8s">
-            <param id="docker_repo_override">docker-registry.phenomenal-h2020.eu</param>
+            <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
             <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">midcor</param>
-            <param id="docker_tag_override">latest</param>
+            <param id="docker_tag_override">dev_v1.0_cv0.2.30</param>
             <param id="max_pod_retrials">3</param>
             <param id="docker_enabled">true</param>
         </destination>
@@ -81,7 +81,7 @@
             <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
             <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">ramid</param>
-            <param id="docker_tag_override">latest</param>
+            <param id="docker_tag_override">dev_v1.0_cv0.1.4</param>
             <param id="max_pod_retrials">3</param>
             <param id="docker_enabled">true</param>
         </destination>

--- a/tools/phenomenal/fluxomics/iso2flux/iso2flux.xml
+++ b/tools/phenomenal/fluxomics/iso2flux/iso2flux.xml
@@ -2,7 +2,7 @@
 <stdio>
 <exit_code range="1:" />
 </stdio>
-<description>Flux analysis software that allows to perform 13C Metabolic Flux Analysis on a sub-network of a large scale model.</description>
+<description>13C Metabolic Flux Analysis on a sub-network of a large scale model.</description>
 <command><![CDATA[
 echo 'Working directory is '\$PWD;
 run_iso2flux.py -e "$tracing_data"

--- a/tools/phenomenal/fluxomics/iso2flux/iso2flux.xml
+++ b/tools/phenomenal/fluxomics/iso2flux/iso2flux.xml
@@ -1,16 +1,13 @@
-<tool id="iso2flux" name="iso2flux" version="0.1.0">
+<tool id="iso2flux" name="iso2flux" version="0.2">
 <stdio>
 <exit_code range="1:" />
 </stdio>
+<description>Flux analysis software that allows to perform 13C Metabolic Flux Analysis on a sub-network of a large scale model.</description>
 <command><![CDATA[
 echo 'Working directory is '\$PWD;
-#if str( $tracing_model ) != None:
-#set $tracing_model_wext = str( $tracing_model ) + '.xlsx'
-ln -s "$tracing_model" "$tracing_model_wext";
-#end if
 run_iso2flux.py -e "$tracing_data"
 #if str( $tracing_model ) != None:
-  -l "$tracing_model_wext"
+  -l "$tracing_model"
 #end if
 
 -s "$sbml_model"
@@ -22,8 +19,6 @@ run_iso2flux.py -e "$tracing_data"
 -c "$constraints"
 #end if
 
--t "$incubation_time"
--f "$experimental_factor"
 
 #if str( $confidence.compute ) == "no":
 -q
@@ -34,12 +29,10 @@ run_iso2flux.py -e "$tracing_data"
  -->
 <inputs>
     <param type="data" name="tracing_data" format="csv" />
-    <param type="data" name="tracing_model" format="xlsx"/>
+    <param type="data" name="tracing_model" format="csv"/>
     <param type="data" name="sbml_model" format="xml"/>
     <param type="data" name="parameters" format="csv" optional="True"/>
     <param type="data" name="constraints" format="csv" optional="True"/>
-    <param type="float" name="incubation_time" value="1"/>
-    <param type="text" name="experimental_factor" value="Factor"/>
     <conditional name="confidence">
         <param name="compute" label="Compute confidence intervals" type="select">
             <option value="yes">Yes</option>
@@ -48,21 +41,27 @@ run_iso2flux.py -e "$tracing_data"
     </conditional>
 </inputs>
 <outputs>
-    <data name="unconstrained_fluxes" format="csv" from_work_dir="unconstrained_fluxes.csv" label="Unconstrained fluxes"/>
-    <data name="best_label" format="csv" from_work_dir="best_label.csv" label="Best label"/>
-    <data name="best_fluxes" format="csv" from_work_dir="best_fluxes.csv" label="Best fluxes after adjustment"/>
-    <data name="fluxes_confidence" format="csv" frow_work_dir="confidence.csv" label="Confidence intervals for fluxes">
+    <data name="best_fit" format="csv" from_work_dir="best_fit.csv" label="Best Fit"/>
+    <data name="constrained_sbml_model" format="xml" from_work_dir="constrained_model.xml" label="SBML model constrained with the results of 13C analysis"/>
+    <data name="fluxes_confidence" format="csv" frow_work_dir="confidence.csv" label="Confidence intervals for all fluxes">
         <filter>( confidence['compute'] == "yes")</filter>
     </data>
-    <!--
-     Outputs:
-     - unconstrained fluxes (csv) : prefix+"unconstrained_fluxes.csv"
-     - best label (best tracer) (csv) : prefix+"best_label.csv"
-     - best fluxes (best adjustement) (csv) : prefix+"best_fluxes.csv"
-     - confidence for fluxes (csv) : prefix+"confidence.csv"
-    -->
 
 </outputs>
 <help><![CDATA[
+A script that performs 13C Metabolic Flux Analysis with the software Iso2flux. It will find the flux distribution most consistent with experimental tracer data and (if not disabled) also estimate confidence interval for fluxes.  
+Options:
+experimental_data_file= Name of the processed Metabolights file containing isotopologues distribution.
+tracing_model= Name of the CSV file describing the label propagation rules
+sbml_model= Name of the SBML file describing the constraint based model that will be used
+parameters= Name of the CSV file defining additional parameters for Iso2flux (Optional)
+constraints= Name of the file containing additional constraints for the constraint model (Optional)
+quick_analysis Disables the confidence interval analysis (Optional)
+
+Output:
+best_fit.csv:The simulated fluxes and label distribution that are most consistent with experimental measurements
+constrained_sbml_model.xml: A SBML model constraiend with the results of the 13C analysis.
+confidence.csv:The lower and upper limits of the confidence intervals for fluxes
+
 ]]></help>
 </tool>

--- a/tools/phenomenal/fluxomics/midcor/midcor.xml
+++ b/tools/phenomenal/fluxomics/midcor/midcor.xml
@@ -2,6 +2,7 @@
 <stdio>
 <exit_code range="1:" />
 </stdio>
+<description>corrects 13C mass isotopomers spectra of metabolites for natural occurring isotopes and peaks overlapping.</description>
 <command><![CDATA[
 runMidcor.R -i "$input1" -o "$output1"
 ]]></command>
@@ -12,6 +13,6 @@ runMidcor.R -i "$input1" -o "$output1"
     <data name="output1" format="csv" label="Corrected isotopologues file"/>
 </outputs>
 <help><![CDATA[
-TODO: Fill in help.
-]]></help>
+	midcor is an R program that performs a primary analysis of isotopic isomers (isotopomers) distribution obtained by Gas Cromatography coupled with Mass Spectrometry (GCMS). The aim of this analysis is to have a corrected distribution of isotopes originated from substrates that are artificially enriched with specific isotopes (usually 13C). To this end the program performs a correction for natural occurring isotopes and also correction for “impurities” of the assay media that give peaks overlapping with the spectra of analyzed labeled metabolites. This program offers two ways of corrections of “impurities” resulted from overlapping the assayed mass isotopomer distribution with peaks produced either by unknown metabolites in the media, or by different fragments produced by the assayed metabolite.
+	]]></help>
 </tool>

--- a/tools/phenomenal/fluxomics/ramid/ramid.xml
+++ b/tools/phenomenal/fluxomics/ramid/ramid.xml
@@ -11,7 +11,7 @@ runRamid.R -i "$inputExchange" -o "$outputExchange" -z "$zipped_data"
 	<param type="data" name="zipped_data" format="zip" />
 </inputs>
 <outputs>
-    <data name="outputExchange" format="csv" label="Corrected isotopologues file"/>
+    <data name="outputExchange" format="csv" label="Isotopologues file"/>
 </outputs>
 <help>
 ==============

--- a/workflows/Galaxy-Workflow-fluxomics-stationary-0.2.ga
+++ b/workflows/Galaxy-Workflow-fluxomics-stationary-0.2.ga
@@ -1,0 +1,322 @@
+{
+    "a_galaxy_workflow": "true", 
+    "annotation": "", 
+    "format-version": "0.1", 
+    "name": "fluxomics-stationary-0.2", 
+    "steps": {
+        "0": {
+            "annotation": "", 
+            "content_id": null, 
+            "id": 0, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "", 
+                    "name": "exchange_file"
+                }
+            ], 
+            "label": null, 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 200, 
+                "top": 200
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"exchange_file\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "d01a2d19-536d-4866-9ded-13b92ea973ad", 
+            "workflow_outputs": []
+        }, 
+        "1": {
+            "annotation": "", 
+            "content_id": null, 
+            "id": 1, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "", 
+                    "name": "zip_netCDF"
+                }
+            ], 
+            "label": null, 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 205, 
+                "top": 338
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"zip_netCDF\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "a5e1972f-e203-4fa7-be07-addca7674dc0", 
+            "workflow_outputs": []
+        }, 
+        "2": {
+            "annotation": "", 
+            "content_id": null, 
+            "id": 2, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "", 
+                    "name": "tracing model"
+                }
+            ], 
+            "label": null, 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 458, 
+                "top": 531
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"tracing model\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "57c35812-9167-4ce3-9275-fded930320f5", 
+            "workflow_outputs": []
+        }, 
+        "3": {
+            "annotation": "", 
+            "content_id": null, 
+            "id": 3, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "", 
+                    "name": "SBML input"
+                }
+            ], 
+            "label": null, 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 456, 
+                "top": 613
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"SBML input\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "51231172-9725-4bd8-a819-095380f77d2b", 
+            "workflow_outputs": []
+        }, 
+        "4": {
+            "annotation": "", 
+            "content_id": null, 
+            "id": 4, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "", 
+                    "name": "constraints"
+                }
+            ], 
+            "label": null, 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 463.140625, 
+                "top": 689.328125
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"constraints\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "uuid": "afc82514-e911-4b5c-b783-75513637b660", 
+            "workflow_outputs": []
+        }, 
+        "5": {
+            "annotation": "", 
+            "content_id": "ramid", 
+            "id": 5, 
+            "input_connections": {
+                "inputExchange": {
+                    "id": 0, 
+                    "output_name": "output"
+                }, 
+                "zipped_data": {
+                    "id": 1, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool ramid", 
+                    "name": "zipped_data"
+                }, 
+                {
+                    "description": "runtime parameter for tool ramid", 
+                    "name": "inputExchange"
+                }
+            ], 
+            "label": null, 
+            "name": "ramid", 
+            "outputs": [
+                {
+                    "name": "outputExchange", 
+                    "type": "csv"
+                }
+            ], 
+            "position": {
+                "left": 394, 
+                "top": 265
+            }, 
+            "post_job_actions": {}, 
+            "tool_errors": null, 
+            "tool_id": "ramid", 
+            "tool_state": "{\"zipped_data\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"inputExchange\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
+            "tool_version": "0.1.0", 
+            "type": "tool", 
+            "uuid": "64464c51-c8fa-42af-a7f4-f41375e6abf8", 
+            "workflow_outputs": [
+                {
+                    "label": "ramid_output", 
+                    "output_name": "outputExchange", 
+                    "uuid": "f9553e0c-f94b-46b7-8756-2ef8f62eb8a9"
+                }
+            ]
+        }, 
+        "6": {
+            "annotation": "", 
+            "content_id": "midcor", 
+            "id": 6, 
+            "input_connections": {
+                "input1": {
+                    "id": 5, 
+                    "output_name": "outputExchange"
+                }
+            }, 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool midcor", 
+                    "name": "input1"
+                }
+            ], 
+            "label": null, 
+            "name": "midcor", 
+            "outputs": [
+                {
+                    "name": "output1", 
+                    "type": "csv"
+                }
+            ], 
+            "position": {
+                "left": 600, 
+                "top": 411
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionoutput1": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "output1"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "midcor", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
+            "tool_version": "0.1.0", 
+            "type": "tool", 
+            "uuid": "80ac7702-84fe-445b-b5de-f2dddc56e017", 
+            "workflow_outputs": []
+        }, 
+        "7": {
+            "annotation": "", 
+            "content_id": "iso2flux", 
+            "id": 7, 
+            "input_connections": {
+                "constraints": {
+                    "id": 4, 
+                    "output_name": "output"
+                }, 
+                "sbml_model": {
+                    "id": 3, 
+                    "output_name": "output"
+                }, 
+                "tracing_data": {
+                    "id": 6, 
+                    "output_name": "output1"
+                }, 
+                "tracing_model": {
+                    "id": 2, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool iso2flux", 
+                    "name": "tracing_data"
+                }, 
+                {
+                    "description": "runtime parameter for tool iso2flux", 
+                    "name": "parameters"
+                }, 
+                {
+                    "description": "runtime parameter for tool iso2flux", 
+                    "name": "sbml_model"
+                }, 
+                {
+                    "description": "runtime parameter for tool iso2flux", 
+                    "name": "tracing_model"
+                }, 
+                {
+                    "description": "runtime parameter for tool iso2flux", 
+                    "name": "constraints"
+                }
+            ], 
+            "label": null, 
+            "name": "iso2flux", 
+            "outputs": [
+                {
+                    "name": "best_fit", 
+                    "type": "csv"
+                }, 
+                {
+                    "name": "constrained_sbml_model", 
+                    "type": "xml"
+                }, 
+                {
+                    "name": "fluxes_confidence", 
+                    "type": "csv"
+                }
+            ], 
+            "position": {
+                "left": 805, 
+                "top": 477
+            }, 
+            "post_job_actions": {
+                "HideDatasetActionbest_fit": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "best_fit"
+                }, 
+                "HideDatasetActionconstrained_sbml_model": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "constrained_sbml_model"
+                }, 
+                "HideDatasetActionfluxes_confidence": {
+                    "action_arguments": {}, 
+                    "action_type": "HideDatasetAction", 
+                    "output_name": "fluxes_confidence"
+                }
+            }, 
+            "tool_errors": null, 
+            "tool_id": "iso2flux", 
+            "tool_state": "{\"tracing_data\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"confidence\": \"{\\\"compute\\\": \\\"no\\\", \\\"__current_case__\\\": 1}\", \"parameters\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"__page__\": 0, \"__rerun_remap_job_id__\": null, \"sbml_model\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"tracing_model\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\", \"constraints\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}", 
+            "tool_version": "0.2", 
+            "type": "tool", 
+            "uuid": "d87f38a7-d735-498a-8e94-a11026822d40", 
+            "workflow_outputs": []
+        }
+    }, 
+    "uuid": "cd24a057-0ae5-424b-8c4b-75732d7537a4"
+}


### PR DESCRIPTION
This PR: 
- Sets the versions for the fluxomics tools for the stationary analysis workflow, based on version series cv0.2.x of iso2flux container. 
- Adds some documentation and description of the fluxomics tools in Galaxy. 
- Includes an exported version of the fluxomics stationary analysis workflow at 0.2 version, for later import through the API. 
- Fixes the iso2flux Galaxy XML wrapper to be compatible with the cv0.2.x iso2flux container series.

Could either @ilveroluca or @pierrickrogermele please review and approve for merge? Thanks. I have tried all these tools (except for isodyn, for which I don't provide any changes at this PR) to work fine on Minikube, both in a workflow and independently.

I'll use @cfoguet changes on #7 later on for version cv0.3.x which will use two output files instead of a single best fit files, but not as part of this PR. Please don't merge #7 just yet.