### PR TITLE
Clone galaxy repo without its history to build the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     pip install --upgrade pip && \
     apt-get purge -y software-properties-common && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN git clone https://github.com/phnmnl/galaxy.git
+RUN git clone --depth 1 --single-branch --branch feature/allfeats https://github.com/phnmnl/galaxy.git
 WORKDIR galaxy
 RUN git checkout feature/allfeats
 RUN echo "-e git+https://github.com/pcm32/pykube.git@feature/allMergedFeatures#egg=pykube" >> requirements.txt


### PR DESCRIPTION
When building the Docker image, we can clone the Galaxy repo without all the project history (a shallow checkout).  The change reduces the size of the `galaxy-k8s-runtime` image from 793.6 MB 568.4 MB.