### PR TITLE
Develop xcms

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -57,7 +57,7 @@
             <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
             <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">iso2flux</param>
-            <param id="docker_tag_override">dev_v0.2_cv0.2.23</param>
+            <param id="docker_tag_override">v0.2_cv1.0.28</param>
             <param id="max_pod_retrials">1</param>
             <param id="docker_enabled">true</param>
         </destination>
@@ -65,7 +65,7 @@
             <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
             <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">midcor</param>
-            <param id="docker_tag_override">dev_v1.0_cv0.2.30</param>
+            <param id="docker_tag_override">v1.0_cv0.2.32</param>
             <param id="max_pod_retrials">3</param>
             <param id="docker_enabled">true</param>
         </destination>
@@ -81,7 +81,7 @@
             <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
             <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">ramid</param>
-            <param id="docker_tag_override">dev_v1.0_cv0.1.4</param>
+            <param id="docker_tag_override">v1.0_cv0.1.7</param>
             <param id="max_pod_retrials">3</param>
             <param id="docker_enabled">true</param>
         </destination>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -180,8 +180,8 @@
 	    <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
             <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">scp-aspera</param>
-            <param id="docker_tag_override">latest</param>
-            <param id="max_pod_retrials">3</param>
+            <param id="docker_tag_override">v3.5.4.102989-linux-64_cv0.1.5</param>
+            <param id="max_pod_retrials">1</param>
             <param id="docker_enabled">true</param>
         </destination>
         <destination id="mtbls-labs-uploader-container" runner="k8s">

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -164,7 +164,7 @@
 	    <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
             <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">mzml2isa</param>
-            <param id="docker_tag_override">latest</param>
+            <param id="docker_tag_override">v0.4.28_cv0.2.23</param>
             <param id="max_pod_retrials">3</param>
             <param id="docker_enabled">true</param>
         </destination>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -212,7 +212,7 @@
             <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
             <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">ms-vfetc</param>
-            <param id="docker_tag_override">latest</param>
+            <param id="docker_tag_override">v0.4_cv1.3.10</param>
             <param id="max_pod_retrials">3</param>
             <param id="docker_enabled">true</param>
         </destination>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -239,7 +239,8 @@
         <tool id="lcmsmatching" destination="w4m-lcmsmatching-container"/>
         <tool id="msconvert2" destination="msconvert2-container"/>
         <tool id="nmrmlconv" destination="nmrmlconv-container"/>
-        <tool id="show_chromatogram" destination="rtest-container"/>
+	<tool id="save_chromatogram" destination="xcms-container"/>
+        <tool id="show_chromatogram" destination="xcms-container"/>
         <tool id="mzml2isa" destination="mzml2isa-container"/>
         <tool id="nmrml2isa" destination="nmrml2isa-container"/>
         <tool id="mtbls-downloader" destination="mtbls-downloader-container"/>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -172,7 +172,7 @@
 	    <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
             <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">nmrml2isa</param>
-            <param id="docker_tag_override">latest</param>
+            <param id="docker_tag_override">v0.3.0_cv0.1.10</param>
             <param id="max_pod_retrials">3</param>
             <param id="docker_enabled">true</param>
         </destination>

--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -71,6 +71,7 @@
   </section>
   <section name="MS" id="pheno-ms">
     <tool file="phenomenal/ms/msconvert2.xml"/>
+    <tool file="phenomenal/ms/save_chromatogram.xml"/>
     <tool file="phenomenal/ms/show_chromatogram.xml"/>
     <tool file="phenomenal/ms/mzml2isa/mzml2isa.xml"/>
     <tool file="phenomenal/ms/metfrag.xml"/>

--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -59,7 +59,9 @@
     <tool file="phenomenal/fluxomics/ramid/ramid.xml"/>
     <tool file="phenomenal/fluxomics/midcor/midcor.xml"/>
     <tool file="phenomenal/fluxomics/iso2flux/iso2flux.xml"/>
+    <!--
     <tool file="phenomenal/fluxomics/isodyn/isodyn.xml"/>
+    -->
   </section>
   <section name="NMR" id="pheno-nmr">
     <tool file="phenomenal/nmr/batman.xml"/>

--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -40,6 +40,7 @@
     <tool file="plotting/boxplot.xml" />
   </section>
   <label id="phenomenal" text="PhenoMeNal H2020 Tools" />
+  <!--
   <section name="Uppsala Workshop" id="uppsala">
     <tool file="phenomenal/uppsala/BlankFilter/BlankFilter.xml"/>
     <tool file="phenomenal/uppsala/BatchFeatureRemoval/BatchFeatureRemoval.xml"/>
@@ -49,6 +50,7 @@
     <tool file="uppsala/Merger/Merger.xml"/>
     <tool file="uppsala/FeatureSelection/FeatureSelection.xml"/>
   </section>
+  -->
   <section name="Transfer" id="metabolomics_transfer">
     <tool file="phenomenal/transfer/metabolights-downloader.xml"/>
     <tool file="phenomenal/transfer/metabolights-labs-uploader.xml"/>

--- a/tools/phenomenal/fluxomics/iso2flux/iso2flux.xml
+++ b/tools/phenomenal/fluxomics/iso2flux/iso2flux.xml
@@ -1,4 +1,4 @@
-<tool id="iso2flux" name="iso2flux" version="0.2">
+<tool id="iso2flux" name="iso2flux" version="1.0">
 <stdio>
 <exit_code range="1:" />
 </stdio>
@@ -41,7 +41,8 @@ run_iso2flux.py -e "$tracing_data"
     </conditional>
 </inputs>
 <outputs>
-    <data name="best_fit" format="csv" from_work_dir="best_fit.csv" label="Best Fit"/>
+    <data name="best_fit_fluxes" format="csv" from_work_dir="best_fluxes.csv" label="Best fit fluxes"/>
+    <data name="best_fit_label" format="csv" from_work_dir="best_label.csv" label="Best fit label"/>
     <data name="constrained_sbml_model" format="xml" from_work_dir="constrained_model.xml" label="SBML model constrained with the results of 13C analysis"/>
     <data name="fluxes_confidence" format="csv" frow_work_dir="confidence.csv" label="Confidence intervals for all fluxes">
         <filter>( confidence['compute'] == "yes")</filter>

--- a/tools/phenomenal/ms/save_chromatogram.xml
+++ b/tools/phenomenal/ms/save_chromatogram.xml
@@ -1,20 +1,20 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--Proposed Tool Section: [Statistics]-->
-<tool id="show_chromatogram" name="show_chromatogram" version="1.1">
+<tool id="save_chromatogram" name="save_chromatogram" version="1.1">
 <!--
   <requirements>
     <container type="docker">phnmnl/xcms</container>
   </requirements>
 -->
-  <description>Shows the chromatogram of a single mzML file.</description>
+  <description>Saves the chromatogram of a single mzML file.</description>
   <command><![CDATA[
-    /usr/local/bin/show_chromatogram.r $infile $outfile 2>&1
+    /usr/local/bin/save_chromatogram.r $infile $outfile 2>&1
   ]]></command>
   <inputs>
     <param name="infile" type="data" format="mzml" value="&lt;class 'CTDopts.CTDopts._Null'&gt;" optional="False" label="Input mzML file." />
   </inputs>
   <outputs>
-    <data name="outfile" format="png"/>
+    <data name="outfile" format="csv"/>
   </outputs>
-  <help>Produces a PNG image file out of an mzML file as input.</help>
+  <help>Saves the chromatogram RT/TIC out of an mzML file in CSV format.</help>
 </tool>


### PR DESCRIPTION
added:

    save_chromatogram
    show_chromatogram

These are two very basic tools that should only be used to convert single mzML files to csv data matrix or show a png of the raw chromatogram for testing purposes.