### PR TITLE
develop_xcms

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -239,7 +239,8 @@
         <tool id="lcmsmatching" destination="w4m-lcmsmatching-container"/>
         <tool id="msconvert2" destination="msconvert2-container"/>
         <tool id="nmrmlconv" destination="nmrmlconv-container"/>
-        <tool id="show_chromatogram" destination="rtest-container"/>
+	<tool id="save_chromatogram" destination="xcms-container"/>
+        <tool id="show_chromatogram" destination="xcms-container"/>
         <tool id="mzml2isa" destination="mzml2isa-container"/>
         <tool id="nmrml2isa" destination="nmrml2isa-container"/>
         <tool id="mtbls-downloader" destination="mtbls-downloader-container"/>

--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -71,6 +71,7 @@
   </section>
   <section name="MS" id="pheno-ms">
     <tool file="phenomenal/ms/msconvert2.xml"/>
+    <tool file="phenomenal/ms/save_chromatogram.xml"/>
     <tool file="phenomenal/ms/show_chromatogram.xml"/>
     <tool file="phenomenal/ms/mzml2isa/mzml2isa.xml"/>
     <tool file="phenomenal/ms/metfrag.xml"/>

--- a/tools/phenomenal/ms/save_chromatogram.xml
+++ b/tools/phenomenal/ms/save_chromatogram.xml
@@ -8,7 +8,7 @@
 -->
   <description>Saves the chromatogram of a single mzML file.</description>
   <command><![CDATA[
-    /usr/local/bin/save_chromatogram.r $infile $outfile 2>&1
+    save_chromatogram.r $infile $outfile 2>&1
   ]]></command>
   <inputs>
     <param name="infile" type="data" format="mzml" value="&lt;class 'CTDopts.CTDopts._Null'&gt;" optional="False" label="Input mzML file." />

--- a/tools/phenomenal/ms/save_chromatogram.xml
+++ b/tools/phenomenal/ms/save_chromatogram.xml
@@ -1,20 +1,20 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--Proposed Tool Section: [Statistics]-->
-<tool id="show_chromatogram" name="show_chromatogram" version="1.1">
+<tool id="save_chromatogram" name="save_chromatogram" version="1.1">
 <!--
   <requirements>
     <container type="docker">phnmnl/xcms</container>
   </requirements>
 -->
-  <description>Shows the chromatogram of a single mzML file.</description>
+  <description>Saves the chromatogram of a single mzML file.</description>
   <command><![CDATA[
-    /usr/local/bin/show_chromatogram.r $infile $outfile 2>&1
+    /usr/local/bin/save_chromatogram.r $infile $outfile 2>&1
   ]]></command>
   <inputs>
     <param name="infile" type="data" format="mzml" value="&lt;class 'CTDopts.CTDopts._Null'&gt;" optional="False" label="Input mzML file." />
   </inputs>
   <outputs>
-    <data name="outfile" format="png"/>
+    <data name="outfile" format="csv"/>
   </outputs>
-  <help>Produces a PNG image file out of an mzML file as input.</help>
+  <help>Saves the chromatogram RT/TIC out of an mzML file in CSV format.</help>
 </tool>

--- a/tools/phenomenal/ms/show_chromatogram.xml
+++ b/tools/phenomenal/ms/show_chromatogram.xml
@@ -8,7 +8,7 @@
 -->
   <description>Shows the chromatogram of a single mzML file.</description>
   <command><![CDATA[
-    /usr/local/bin/show_chromatogram.r $infile $outfile 2>&1
+    show_chromatogram.r $infile $outfile 2>&1
   ]]></command>
   <inputs>
     <param name="infile" type="data" format="mzml" value="&lt;class 'CTDopts.CTDopts._Null'&gt;" optional="False" label="Input mzML file." />


### PR DESCRIPTION
added:

    save_chromatogram
    show_chromatogram

These are two very basic tools that should only be used to convert single mzML files to csv data matrix or show a png of the raw chromatogram for testing purposes.