### PR TITLE
Moves to Galaxy 17.01-dev + new features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     pip install --upgrade pip && \
     apt-get purge -y software-properties-common && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN git clone --depth 1 --single-branch --branch feature/allfeats_no_interpreter_removal https://github.com/phnmnl/galaxy.git
+RUN git clone --depth 1 --single-branch --branch feature/k8s_supplementalGroup_support https://github.com/phnmnl/galaxy.git
 WORKDIR galaxy
 RUN echo "-e git+https://github.com/pcm32/pykube.git@feature/allMergedFeatures#egg=pykube" >> requirements.txt
 COPY config/galaxy.ini config/galaxy.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:14.04
 MAINTAINER PhenoMeNal-H2020 Project <phenomenal-h2020-users@googlegroups.com>
 
-LABEL Description="Galaxy 16.07-phenomenal for running inside Kubernetes."
+LABEL Description="Galaxy 17.01-phenomenal for running inside Kubernetes."
 LABEL software="Galaxy"
-LABEL software.version="16.07-pheno"
+LABEL software.version="17.01-pheno"
 LABEL version="1.0"
 
 RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transport-https software-properties-common wget && \
@@ -14,7 +14,7 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     pip install --upgrade pip && \
     apt-get purge -y software-properties-common && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN git clone --depth 1 --single-branch --branch feature/k8s_supplementalGroup_support https://github.com/phnmnl/galaxy.git
+RUN git clone --depth 1 --single-branch --branch feature/pr_fs_access_job_version https://github.com/phnmnl/galaxy.git
 WORKDIR galaxy
 RUN echo "pykube==0.15.0" >> requirements.txt
 COPY config/galaxy.ini config/galaxy.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER PhenoMeNal-H2020 Project <phenomenal-h2020-users@googlegroups.com>
 LABEL Description="Galaxy 16.07-phenomenal for running inside Kubernetes."
 LABEL software="Galaxy"
 LABEL software.version="16.07-pheno"
-LABEL version="0.2"
+LABEL version="1.0"
 
 RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transport-https software-properties-common wget && \
     apt-get update -qq && \
@@ -16,7 +16,7 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN git clone --depth 1 --single-branch --branch feature/k8s_supplementalGroup_support https://github.com/phnmnl/galaxy.git
 WORKDIR galaxy
-RUN echo "-e git+https://github.com/pcm32/pykube.git@feature/allMergedFeatures#egg=pykube" >> requirements.txt
+RUN echo "pykube==0.15.0" >> requirements.txt
 COPY config/galaxy.ini config/galaxy.ini
 COPY config/job_conf.xml config/job_conf.xml
 COPY config/tool_conf.xml config/tool_conf.xml

--- a/ansible/run_galaxy_config.sh
+++ b/ansible/run_galaxy_config.sh
@@ -47,6 +47,13 @@ if [ ! -z $GALAXY_PVC ]; then
   log "Set PersistentVolumeClaim to use with Galaxy to $GALAXY_PVC on job_conf.xml"
 fi
 
+if [ ! -z $GALAXY_TOOLS_PULL_POLICY ]; then
+  mv config/job_conf.xml config/job_conf.xml.original
+  sed s/k8s_pull_policy\"\>.*\</k8s_pull_policy\"\>$GALAXY_TOOLS_PULL_POLICY\</ config/job_conf.xml.original > config/job_conf.xml
+  log "Set k8s pull policy to use with Galaxy to $GALAXY_TOOLS_PULL_POLICY on job_conf.xml"
+fi
+
+
 # if admin email, api and password env variables are set, then start galaxy, run user creation and stop galaxy
 if [ ! -z $GALAXY_ADMIN_EMAIL ] && [ ! -z $GALAXY_ADMIN_PASSWORD ] && [ ! -z $GALAXY_API_KEY ]; then
   # ini file will be set already at this point with these variables, we only need to start galaxy

--- a/ansible/run_galaxy_config.sh
+++ b/ansible/run_galaxy_config.sh
@@ -23,6 +23,18 @@ sudo apt-get update -y && sudo apt-get install -y --no-install-recommends ansibl
 ansible-playbook -i "localhost," -c local ansible/set-galaxy-config-values.yaml
 log "Playbook for galaxy config run."
 
+if [ ! -z $SUPP_GROUPS ]
+  mv config/job_conf.xml config/job_conf.xml.original
+  sed s/\"k8s_supplemental_group_id\"\>0/\"k8s_supplemental_group_id\"\>$SUPP_GROUPS/ config/job_conf.xml.original > config/job_conf.xml
+  log "Changed supplemental group id from 0 to $SUPP_GROUPS on job_conf.xml"
+fi
+
+if [ ! -z $GALAXY_PVC ]
+  mv config/job_conf.xml config/job_conf.xml.original
+  sed s/k8s_persistent_volume_claim_name\"\>.*\</k8s_persistent_volume_claim_name\"\>$GALAXY_PVC\</ config/job_conf.xml.original > config/job_conf.xml
+  log "Set PersistentVolumeClaim to use with Galaxy to $GALAXY_PVC on job_conf.xml"
+fi
+
 # if admin email, api and password env variables are set, then start galaxy, run user creation and stop galaxy
 if [ ! -z $GALAXY_ADMIN_EMAIL ] && [ ! -z $GALAXY_ADMIN_PASSWORD ] && [ ! -z $GALAXY_API_KEY ]; then
   # ini file will be set already at this point with these variables, we only need to start galaxy

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -10,7 +10,8 @@
             set in universe_wsgi.ini (or equivalent general galaxy config file).
             -->
             <param id="k8s_persistent_volume_claim_mount_path">/opt/galaxy_data</param>
-            <param id="k8s_namespace">default</param>
+	    <param id="k8s_namespace">default</param>
+	    <param id="k8s_supplemental_group_id">0</param>
             <!-- Allows pods to retry up to this number of times, before marking the Job as failed -->
             <param id="k8s_pod_retrials">1</param>
         </plugin>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -13,6 +13,7 @@
 	    <param id="k8s_namespace">default</param>
 	    <param id="k8s_supplemental_group_id">0</param>
 	    <param id="k8s_fs_group_id">0</param>
+	    <param id="k8s_pull_policy">IfNotPresent</param>
             <!-- Allows pods to retry up to this number of times, before marking the Job as failed -->
             <param id="k8s_pod_retrials">1</param>
         </plugin>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -12,6 +12,7 @@
             <param id="k8s_persistent_volume_claim_mount_path">/opt/galaxy_data</param>
 	    <param id="k8s_namespace">default</param>
 	    <param id="k8s_supplemental_group_id">0</param>
+	    <param id="k8s_fs_group_id">0</param>
             <!-- Allows pods to retry up to this number of times, before marking the Job as failed -->
             <param id="k8s_pod_retrials">1</param>
         </plugin>

--- a/html/welcome.html
+++ b/html/welcome.html
@@ -29,7 +29,7 @@
 	</p>
 
 	<p class="lead">
-	This <a target="_blank" class="reference" href="http://phenomenal-h2020.eu/home/">PhenoMeNal H2020</a> Galaxy instance, and all of its tools, run as containers on top of <a target="_blank" class="reference" href="http://kubernetes.io/">Kubernetes</a>, an open source container orchestrator system backed by Google. If you wish to deploy the <a target="_blank" class="reference" href="https://github.com/phnmnl/docker-galaxy-k8s-runtime/tree/develop">PhenoMeNal Galaxy installation</a> on top of your own Kubernetes instance, you can find instructions at our <a target="_blank" class="reference" href="http://phenomenal-h2020.eu/home/wiki/#galaxy-with-k8s">wiki</a>.
+	This <a target="_blank" class="reference" href="http://phenomenal-h2020.eu/home/">PhenoMeNal H2020</a> Galaxy instance, and all of its tools, run as containers on top of <a target="_blank" class="reference" href="http://kubernetes.io/">Kubernetes</a>, an open source container orchestrator system backed by Google. If you wish to deploy the <a target="_blank" class="reference" href="https://github.com/phnmnl/docker-galaxy-k8s-runtime/tree/develop">PhenoMeNal Galaxy installation</a> on top of your own Kubernetes instance, you can find instructions at our <a target="_blank" class="reference" href="http://portal.phenomenal-h2020.eu/help/galaxy-with-k8s">wiki</a>.
 	</p>
 
         <footer>


### PR DESCRIPTION
This PR:

- Moves container to use a 17.01-dev version of Galaxy.
   - Include new features for the Kubernetes runner:
      - k8s `imagePullPolicy` transferred to spawned Jobs
      - k8s `fsGroup` support for mounting privileged shared file system
      - k8s `supplementalGroups` support for mounting priv. shared file system
      - Ability to inject all these variables through ENVs (for use with Helm).
- Moves to a first 1.0 version of our container
- Detaches from my own branch of pykube, as all features have now been merged upstream
- Uses k8s Job definition version `batch/v1`, which makes our deployment compatible with recently released k8s 1.6 version. 

This has been **fully tested on latest minikube**, to run tools and workflows in different setups for the variables mentioned. 

Doing these changes now should give ample time to have this well stressed tested before our next major release in August.
