### PR TITLE
Moves Galaxy to res 17.05-pheno to fix issue with user creation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:14.04
 MAINTAINER PhenoMeNal-H2020 Project <phenomenal-h2020-users@googlegroups.com>
 
-LABEL Description="Galaxy 17.01-phenomenal for running inside Kubernetes."
+LABEL Description="Galaxy 17.05-phenomenal for running inside Kubernetes."
 LABEL software="Galaxy"
-LABEL software.version="17.01-pheno"
+LABEL software.version="17.05-pheno"
 LABEL version="1.1"
 
 RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transport-https software-properties-common wget && \
@@ -14,7 +14,7 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     pip install --upgrade pip && \
     apt-get purge -y software-properties-common && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN git clone --depth 1 --single-branch --branch feature/pr_fs_access_job_version https://github.com/phnmnl/galaxy.git
+RUN git clone --depth 1 --single-branch --branch release_17.05_plus_k8s_fs_support https://github.com/phnmnl/galaxy.git
 WORKDIR galaxy
 RUN echo "pykube==0.15.0" >> requirements.txt
 COPY config/galaxy.ini config/galaxy.ini


### PR DESCRIPTION
This PR moves to Galaxy 17.05 plus our FS changes (which have been on our docker image for some weeks now). Unfortunately our FS (supplemental group id support, fsGroups support, etc) changes are scheduled for Galaxy release 17.09, so this couldn't be done with 17.05 cleanly and required our FS changes to be re-based on top of rel 17.05 branch. I have tested this to run on minikube. This sorts out the issue of not being able to easily create new users present on 17.01.