### PR TITLE
added two new datatypes required for NMR

### DIFF
--- a/config/datatypes_conf.xml
+++ b/config/datatypes_conf.xml
@@ -196,6 +196,7 @@
     <datatype extension="nhdr" type="galaxy.datatypes.images:Nrrd" subclass="true"/>
     <datatype extension="rna_eps" type="galaxy.datatypes.sequence:RNADotPlotMatrix" mimetype="image/eps" display_in_upload="true"/>
     <datatype extension="zip" type="galaxy.datatypes.binary:CompressedZipArchive" display_in_upload="true"/>
+    <datatype extension="no_unzip.zip" type="galaxy.datatypes.no_unzip_datatypes:NoUnzip" display_in_upload="true" />
     <datatype extension="tar" type="galaxy.datatypes.binary:CompressedArchive" subclass="true" display_in_upload="true"/>
     <!-- Proteomics Datatypes -->
     <datatype extension="pepxml" type="galaxy.datatypes.proteomics:PepXml" mimetype="application/xml" display_in_upload="true"/>
@@ -215,6 +216,7 @@
     <datatype extension="tandem" type="galaxy.datatypes.proteomics:TandemXML" mimetype="application/xml" display_in_upload="true" />
     <datatype extension="thermo.raw" type="galaxy.datatypes.proteomics:ThermoRAW" mimetype="application/octet-stream" display_in_upload="true" />
     <datatype extension="mzml" type="galaxy.datatypes.proteomics:MzML" mimetype="application/xml" display_in_upload="true"/>
+    <datatype extension="nmrml" type="galaxy.datatypes.proteomics:nmrML" display_in_upload="true" mimetype="application/xml" />
     <datatype extension="mgf" type="galaxy.datatypes.proteomics:Mgf" display_in_upload="true" />
     <datatype extension="wiff" type="galaxy.datatypes.proteomics:Wiff" display_in_upload="true" />
     <datatype extension="mzxml" type="galaxy.datatypes.proteomics:MzXML" mimetype="application/xml" display_in_upload="true" />

--- a/external-datatypes/nmrml_datatype.py
+++ b/external-datatypes/nmrml_datatype.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+nmrML datatype
+
+"""
+
+import logging
+import os.path,re
+from galaxy.datatypes.data import *
+from galaxy.datatypes.sniff import *
+from galaxy.datatypes.binary import *
+from galaxy.datatypes.tabular import *
+from galaxy.datatypes.xml import *
+from galaxy.datatypes.proteomics import *
+
+log = logging.getLogger(__name__)
+
+
+class MzML(ProteomicsXml):
+    """nmrML data"""
+    edam_format = "format_3244"
+    file_ext = "nmrml"
+    blurb = 'nmrML Mass Spectrometry data'
+    root = "(nmrML|indexednmrML)"
+
+

--- a/external-datatypes/no_unzip_datatypes.py
+++ b/external-datatypes/no_unzip_datatypes.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+no_unzip_datatypes
+
+A perfect clone of the prims masscomb datatype FileSet
+"""
+
+import logging
+import zipfile 
+import os,os.path,re
+from galaxy.datatypes.data import *
+from galaxy.datatypes.xml import *
+from galaxy.datatypes.sniff import *
+from galaxy.datatypes.binary import *
+from galaxy.datatypes.interval import * 
+
+log = logging.getLogger(__name__)
+    
+
+class NoUnzip( Binary ):
+    """FileSet containing N files"""
+    file_ext = "no_unzip.zip"
+    blurb = "(zipped) FileSet containing multiple files"
+    
+    def sniff( self, filename ):
+        # If the zip file contains multiple files then return true, false otherwise: 
+        zf = zipfile.ZipFile(filename)
+        if (len(zf.infolist())>1):
+            return True
+        else :
+            return False 
+    
+    
+# the if is just for backwards compatibility...could remove this at some point
+if hasattr(Binary, 'register_sniffable_binary_format'):
+    Binary.register_sniffable_binary_format('NoUnzip', 'no_unzip.zip', NoUnzip) 
+    
+    
+    
+    
+    
+    
+
+
+


### PR DESCRIPTION
Hi @pcm32  ,

please merge with baseline so we can proceed with developing the NMR workflows.

no_unzip datatype based on: https://github.com/workflow4metabolomics/xcms/tree/master/galaxy/datatype_no_unzip

@korseby @c-ruttkies @DSchober @sneumann pls check if correct
