### PR TITLE
Adds mtbls factors viz module.

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -259,7 +259,7 @@
 	    <param id="docker_enabled">true</param>
 	</destination>
 	<destination id="container-escher-fluxomics" runner="k8s">
-	    <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
+            <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
 	    <param id="docker_owner_override">phnmnl</param>
 	    <param id="docker_image_override">escher-fluxomics</param>
 	    <param id="docker_tag_override">latest</param>
@@ -302,6 +302,14 @@
            <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
            <param id="docker_owner_override">phnmnl</param>
             <param id="docker_image_override">json2isatab</param>
+           <param id="docker_tag_override">latest</param>
+           <param id="max_pod_retrials">3</param>
+           <param id="docker_enabled">true</param>
+         </destination>
+        <destination id="container-mtbls-factors-viz" runner="k8s">
+           <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
+           <param id="docker_owner_override">phnmnl</param>
+            <param id="docker_image_override">mtbls-factors-viz</param>
            <param id="docker_tag_override">latest</param>
            <param id="max_pod_retrials">3</param>
            <param id="docker_enabled">true</param>
@@ -474,7 +482,8 @@
         <tool id="study_factor_values" destination="container-mtblisa"/>
         <tool id="study_factors" destination="container-mtblisa"/>
         <tool id="data_files" destination="container-mtblisa"/>
-        <tool id="factors_summary" destination="container-mtblisa"/>
+	<tool id="factors_summary" destination="container-mtblisa"/>
+	<tool id="mtbls-factors-viz" destination="container-mtbls-factors-viz"/>
         <tool id="isajson_validator" destination="container-isajson-validator"/>
         <tool id="isatab_validator" destination="container-isatab-validator"/>
         <tool id="isatab2json" destination="container-isatab2json"/>

--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -218,6 +218,7 @@
     <tool file="phenomenal/isatools/study_factor_values.xml"/>
     <tool file="phenomenal/isatools/data_files.xml"/>
     <tool file="phenomenal/isatools/factors_summary.xml"/>
+    <tool file="phenomenal/isatools/mtbls-factors-viz.xml"/>
     <tool file="phenomenal/isatools/isatab_validator.xml"/>
     <tool file="phenomenal/isatools/isajson_validator.xml"/>
     <tool file="phenomenal/isatools/mw2isa.xml"/>

--- a/tools/phenomenal/isatools/mtbls-factors-viz.xml
+++ b/tools/phenomenal/isatools/mtbls-factors-viz.xml
@@ -1,0 +1,37 @@
+<tool id="mtbls-factors-viz" name="MetaboLights Factors Viz" version="0.4">
+<stdio>
+<exit_code range="1:" />
+</stdio>
+<description>Visualizes factors and its values on ISA-Tab and MetaboLights factors JSON</description>
+<command><![CDATA[
+#if $input_type_conditional.input_type == "mtbls-id"
+  makeParallelCoordsPlot.R -s "$input_type_conditional.mtbls_id" -o \$PWD
+#else  
+  makeParallelCoordsPlot.R -i "$input_type_conditional.factors_json" -o \$PWD
+#end if
+
+]]></command>
+<!-- -p, -l -s are optional; tracing data, time and experimental factor are required
+ Missing -q quick mode.
+ -->
+<inputs>
+    <conditional name="input_type_conditional">
+            <param name="input_type" type="select" label="Input Type">
+                <option value="mtbls-id" selected="true">MetaboLights Study Identifier</option>
+                <option value="isa-factors-json">ISA-tab Factors table as JSON file</option>
+            </param>
+            <when value="mtbls-id">
+                 <param name="mtbls_id" type="text" label="MetaboLights Study Identifier" help="MTBLS ID (such as MTBLS200) available at MetaboLights Parallele Coordinates at ftp://ftp.ebi.ac.uk/pub/databases/metabolights/derived/parallel_coordinates/"/>
+            </when>
+            <when value="isa-factors-json">
+	         <param type="data" name="factors_json" format="json" label="ISA-tab factors table in JSON format" />
+	    </when>
+        </conditional>	
+    </inputs>
+<outputs>
+    <data name="factors_plot" format="pdf" from_work_dir="factors_plot.pdf" label="Factors Paralell Sets Plot"/>
+</outputs>
+<help><![CDATA[
+
+]]></help>
+</tool>


### PR DESCRIPTION
This PR adds the mtbls factors viz. This has been tested to work on Minikube, both through direct MTBLS identifier input, or as part of a workflow with get factors summary module (consuming the JSON produced).