### PR TITLE
Adds link to show how to create an account.

### DIFF
--- a/html/welcome.html
+++ b/html/welcome.html
@@ -107,6 +107,7 @@
                             <li><a target="_blank" href="https://www.youtube.com/watch?v=V5M-dcE3qz8&t=88s">LC-MS</a></li>
                             <li><a target="_blank" href="https://www.youtube.com/watch?v=ABW9982s5gY">Statistics</a></li>
                         </ul>-->
+			<li><a target="_blank" href="https://www.ebi.ac.uk/training/online/sites/ebi.ac.uk.training.online/files/CreatingaPhenoMeNalCloudResearchEnvironmentwiththefreePhenoMeNalcloud_0.pdf">Get an account!</a></li>
                         <li><a target="_blank" href="http://phenomenal-h2020.eu/home/help/">Request help</a> (ticket)</li>
                         <li><a target="_blank" href="https://www.ebi.ac.uk/training/online/course/phenomenal-accessing-metabolomics-workflows-galaxy">Online training</a> offered by EMBL-EBI</li>
                         <li>More about setting up a <a target="_blank" href="http://portal.phenomenal-h2020.eu/">private instance</a></li>

--- a/html/welcome.html
+++ b/html/welcome.html
@@ -107,7 +107,7 @@
                             <li><a target="_blank" href="https://www.youtube.com/watch?v=V5M-dcE3qz8&t=88s">LC-MS</a></li>
                             <li><a target="_blank" href="https://www.youtube.com/watch?v=ABW9982s5gY">Statistics</a></li>
                         </ul>-->
-			<li><a target="_blank" href="https://www.ebi.ac.uk/training/online/sites/ebi.ac.uk.training.online/files/CreatingaPhenoMeNalCloudResearchEnvironmentwiththefreePhenoMeNalcloud_0.pdf">Get an account!</a></li>
+			<li><a target="_blank" href="https://portal.phenomenal-h2020.eu/help/How-to-get-a-galaxy-account">How to get an account</a></li>
                         <li><a target="_blank" href="http://phenomenal-h2020.eu/home/help/">Request help</a> (ticket)</li>
                         <li><a target="_blank" href="https://www.ebi.ac.uk/training/online/course/phenomenal-accessing-metabolomics-workflows-galaxy">Online training</a> offered by EMBL-EBI</li>
                         <li>More about setting up a <a target="_blank" href="http://portal.phenomenal-h2020.eu/">private instance</a></li>


### PR DESCRIPTION
This PR adds a missing step on documentation to explain how the user can get an account on the public instance. Initially I have pasted a link to EBI train online, but on second thoughts while writing this, I think we should better link to a Wiki page which explains the two possible cases:
- At the Public instance
- At a VRE deployment of the user
Hopefully we can improve link through this PR. What do you think @michaelvanvliet ?