### PR TITLE
Corrects iso2flux's confidence results not being picked up

### DIFF
--- a/tools/phenomenal/fluxomics/iso2flux/iso2flux.xml
+++ b/tools/phenomenal/fluxomics/iso2flux/iso2flux.xml
@@ -1,4 +1,4 @@
-<tool id="iso2flux" name="iso2flux" version="1.0">
+<tool id="iso2flux" name="iso2flux" version="1.1">
 <stdio>
 <exit_code range="1:" />
 </stdio>
@@ -44,8 +44,8 @@ run_iso2flux.py -e "$tracing_data"
     <data name="best_fit_fluxes" format="csv" from_work_dir="best_fluxes.csv" label="Best fit fluxes"/>
     <data name="best_fit_label" format="csv" from_work_dir="best_label.csv" label="Best fit label"/>
     <data name="constrained_sbml_model" format="xml" from_work_dir="constrained_model.xml" label="SBML model constrained with the results of 13C analysis"/>
-    <data name="fluxes_confidence" format="csv" frow_work_dir="confidence.csv" label="Confidence intervals for all fluxes">
-        <filter>( confidence['compute'] == "yes")</filter>
+    <data name="fluxes_confidence" format="csv" frow_work_dir="confidence_results.csv" label="Confidence intervals for all fluxes">
+        <filter>confidence['compute'] == "yes"</filter>
     </data>
 
 </outputs>


### PR DESCRIPTION
This PR introduces a fix to iso2flux to be able to show confidence results file when they are calculated. Works on minikube. Could this be reviewed so that we can have it on time for the second cloudmet day (Tue 12/09/17). Thanks!