### PR TITLE
[Ticket Phnmnl#20] bugfix: updated xcms galaxy modules

### DIFF
--- a/tools/phenomenal/ms/save_chromatogram.xml
+++ b/tools/phenomenal/ms/save_chromatogram.xml
@@ -1,14 +1,20 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--Proposed Tool Section: [Statistics]-->
-<tool id="save_chromatogram" name="save_chromatogram" version="1.1">
+<tool id="save_chromatogram" name="save_chromatogram" version="1.2">
 <!--
   <requirements>
-    <container type="docker">phnmnl/xcms</container>
+    <container type="docker">container-registry.phenomenal-h2020.eu/phnmnl/xcms</container>
   </requirements>
 -->
-  <description>Saves the chromatogram of a single mzML file.</description>
+  <description>Saves the chromatogram in CSV format of a single mzML file.</description>
   <command><![CDATA[
-    save_chromatogram.r $infile $outfile 2>&1
+if [[ "\$(head -n 2 $infile | tail -n 1 | grep mzML)" != "" ]];
+then filename="\$(head -n 40 $infile | grep "sample id" | sed -e "s/\"\>.*//" | sed -e "s/.*name\=\"//")";
+    xcmsfile="/tmp/\$filename.mzML";
+    cp $infile \$xcmsfile;
+    save_chromatogram.r \$xcmsfile $outfile 2>&1;
+else echo "Error! Input file is not mzML.";
+fi
   ]]></command>
   <inputs>
     <param name="infile" type="data" format="mzml" value="&lt;class 'CTDopts.CTDopts._Null'&gt;" optional="False" label="Input mzML file." />

--- a/tools/phenomenal/ms/show_chromatogram.xml
+++ b/tools/phenomenal/ms/show_chromatogram.xml
@@ -1,14 +1,20 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--Proposed Tool Section: [Statistics]-->
-<tool id="show_chromatogram" name="show_chromatogram" version="1.1">
+<tool id="show_chromatogram" name="show_chromatogram" version="1.2">
 <!--
   <requirements>
-    <container type="docker">phnmnl/xcms</container>
+    <container type="docker">container-registry.phenomenal-h2020.eu/phnmnl/xcms</container>
   </requirements>
 -->
   <description>Shows the chromatogram of a single mzML file.</description>
   <command><![CDATA[
-    show_chromatogram.r $infile $outfile 2>&1
+if [[ "\$(head -n 2 $infile | tail -n 1 | grep mzML)" != "" ]];
+then filename="\$(head -n 40 $infile | grep "sample id" | sed -e "s/\"\>.*//" | sed -e "s/.*name\=\"//")";
+    xcmsfile="/tmp/\$filename.mzML";
+    cp $infile \$xcmsfile;
+    show_chromatogram.r \$xcmsfile $outfile 2>&1;
+else echo "Error! Input file is not mzML.";
+fi
   ]]></command>
   <inputs>
     <param name="infile" type="data" format="mzml" value="&lt;class 'CTDopts.CTDopts._Null'&gt;" optional="False" label="Input mzML file." />


### PR DESCRIPTION
This bugfix to [Ticket Phnmnl#20] adds filetype detection in order to process mzML files correctly with XCMS. The two galaxy modules show_chromatogram and save_chromatogram are affected.