### PR TITLE
Feature/do not delete api key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ COPY config/tool_conf.xml config/tool_conf.xml
 COPY config/sanitize_whitelist.txt config/sanitize_whitelist.txt
 COPY tools/phenomenal tools/phenomenal
 
+RUN virtualenv .config_script_venv
+RUN /bin/bash -c "source .config_script_venv/bin/activate && \
+                  pip install bioblend==0.9.0 && \
+                  deactivate"
+
 RUN virtualenv .venv
 RUN /bin/bash -c "source .venv/bin/activate && \
                   pip install 'pip>=8.1' && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER PhenoMeNal-H2020 Project <phenomenal-h2020-users@googlegroups.com>
 LABEL Description="Galaxy 17.05-phenomenal for running inside Kubernetes."
 LABEL software="Galaxy"
 LABEL software.version="17.05-pheno"
-LABEL version="1.2"
+LABEL version="1.3"
 
 RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transport-https software-properties-common wget && \
     apt-get update -qq && \

--- a/ansible/configure_galaxy.py
+++ b/ansible/configure_galaxy.py
@@ -151,8 +151,14 @@ def configure_admin_user(options):
         admin_user = gi.users.create_local_user(options.username, options.user_email, options.user_password)
         Log.info("Galaxy user %s created!", admin_user['username'])
 
-    admin_user['api_key'] = gi.users.create_user_apikey(admin_user['id'])
-    Log.info("Created API key for admin user %s", admin_user['email'])
+    # associate an API key to the admin user if he doesn't have one
+    admin_api_key = gi.users.get_user_apikey(admin_user['id'])
+    if admin_api_key == 'Not available.':
+        admin_api_key = gi.users.create_user_apikey(admin_user['id'])
+        Log.info("Created API key for admin user %s", admin_user['email'])
+    # set the api_key to the admin user
+    admin_user['api_key'] = admin_api_key
+
     return admin_user
 
 

--- a/ansible/run_galaxy_config.sh
+++ b/ansible/run_galaxy_config.sh
@@ -85,7 +85,7 @@ if [ ! -z $GALAXY_ADMIN_EMAIL ] && [ ! -z $GALAXY_ADMIN_PASSWORD ] && [ ! -z $GA
   end_time=$(date +%s)
   log "Galaxy is up and ready for API calls after $((${end_time} - ${start_time})) seconds."
   log "Running admin user creation..."
-  source .venv/bin/activate
+  source .config_script_venv/bin/activate
   log "Workflow directory: ${WorkflowDir}"
   python ansible/configure_galaxy.py --workflow-dir "${WorkflowDir}" \
      $GALAXY_API_KEY $GALAXY_ADMIN_USER $GALAXY_ADMIN_EMAIL $GALAXY_ADMIN_PASSWORD >&2


### PR DESCRIPTION
This PR adds a virtual environment with bioblend 0.9.0 and restores the commit by @kikkomep to make sure that the admin user's existing API key doesn't get deleted if already existing. I have tested this to work fine on minikube.

Addresses #69 