### PR TITLE
Removes error produced by mass dumping of tools

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -294,9 +294,12 @@
          a tag, a handler or destination that matches that tag will be
          chosen at random.  -->
     <tool id="pathway_enrichment" destination="dynamic-k8s-large" resources="all"/>
+
+    <!-- Uppsala demo tools
     <tool id="BatchFeatureRemoval" destination="batchfeature-container"/>
     <tool id="upps_blankfilter" destination="blankfilter-container"/>
-    <tool id="log2transformation" destination="log2transformation-container"/>
+    <tool id="log2transformation" destination="log2transformation-container"/> -->
+    
     <!-- Fluxomics -->
     <tool id="iso2flux" destination="dynamic-k8s-small" resources="all"/>     
     <tool id="midcor" destination="dynamic-k8s-small" resources="all"/>

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -289,8 +289,6 @@ assignment:
   max_pod_retrials: 3
   tools_id:
   - mw2isa
-- tools_id:
-  - log2transformation
 - docker_image_override: nmrml2isa
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu


### PR DESCRIPTION
log2transform is a tool used for an Uppsala demo that was added to tools2containers incompletely, so it is removed in this PR.