### PR TITLE
Add split isa types to galaxy datatypes configuration

### DIFF
--- a/config/datatypes_conf.xml
+++ b/config/datatypes_conf.xml
@@ -160,8 +160,9 @@
       <display file="igv/interval_as_bed.xml" inherit="true"/>
     </datatype>
 
-    <!-- PhenoMeNal ISA data type -->
-   <datatype extension="isa" type="galaxy.datatypes.isa:Isa" mimetype="application/isa-tools" display_in_upload="true" description="ISA {Tab,JSON} data type." description_url="https://isa-tools.org"/>
+    <!-- ISA data types -->
+    <datatype extension="isa-tab" type="galaxy.datatypes.isa:IsaTab" mimetype="application/isa-tools" display_in_upload="true" description="ISA-Tab data type." description_url="https://isa-tools.org"/>
+    <datatype extension="isa-json" type="galaxy.datatypes.isa:IsaJson" mimetype="application/isa-tools" display_in_upload="true" description="ISA-JSON data type." description_url="https://isa-tools.org"/>
 
     <datatype extension="picard_interval_list" type="galaxy.datatypes.tabular:Tabular" subclass="true" display_in_upload="true">
       <converter file="picard_interval_list_to_bed6_converter.xml" target_datatype="bed6"/>


### PR DESCRIPTION
Since the galaxy configuration in this repo overrides the one in galaxy, this PR copies over the new definitions of the split ISA data types from our galaxy repository.  