### PR TITLE
Remove phantom nmrml galaxy data types

### DIFF
--- a/config/datatypes_conf.xml
+++ b/config/datatypes_conf.xml
@@ -644,8 +644,6 @@
     <datatype extension="smat" type="galaxy.datatypes.plant_tribes:Smat" display_in_upload="true" />
 
     <!-- PhenoMeNal section -->
-    <datatype extension="nmrml" type="galaxy.datatypes.metabolomics:nmrML" mimetype="application/xml" display_in_upload="true"/>
-    <datatype extension="nmrml" type="galaxy.datatypes.proteomics:NmrML" display_in_upload="true" mimetype="application/xml" />
     <datatype extension="no_unzip.zip" type="galaxy.datatypes.no_unzip_datatypes:NoUnzip" display_in_upload="true" />
     <datatype extension="rdata.camera.positive" type="galaxy.datatypes.rdata_camera_datatype:RdataCameraPositive" mimetype="application/x-gzip" subclass="true" display_in_upload="true" />
     <datatype extension="rdata.camera.negative" type="galaxy.datatypes.rdata_camera_datatype:RdataCameraNegative" mimetype="application/x-gzip" subclass="true" display_in_upload="true" />


### PR DESCRIPTION
These data type definitions have been added by us at some point.  They
reference a class that doesn't exist and cause an exception on Galaxy
start-up.  Moreover, they're not used by any of our tools.