### PR TITLE
Update batch_correction tool.

### DIFF
--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -104,7 +104,7 @@ assignment:
 - docker_image_override: batch_correction
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu
-  docker_tag_override: vphenomenal_2017.12.14_cv0.3.4
+  docker_tag_override: v2.2.0_cv0.3.6
   max_pod_retrials: 3
   tools_id:
   - Batch_correction

--- a/tools/phenomenal/w4m/batch_correction.xml
+++ b/tools/phenomenal/w4m/batch_correction.xml
@@ -1,4 +1,4 @@
-<tool id="Batch_correction" name="Batch_correction" version="2.1.2">
+<tool id="Batch_correction" name="Batch_correction" version="2.2.0">
   <description>Corrects intensities for signal drift and batch-effects</description>
 
   <requirements>
@@ -15,7 +15,6 @@
   <command><![CDATA[
     #if str($span_condition.method) == 'all_loess_pool':
         batch_correction_all_loess_wrapper.R
-        
         dataMatrix "$dataMatrix"
         sampleMetadata "$sampleMetadata"
         variableMetadata "$variableMetadata"
@@ -24,7 +23,6 @@
     
     #elif str($span_condition.method) == 'all_loess_sample':
         batch_correction_all_loess_wrapper.R
-        
         dataMatrix "$dataMatrix"
         sampleMetadata "$sampleMetadata"
         variableMetadata "$variableMetadata"
@@ -32,7 +30,6 @@
         span "${span_condition.span}"
     #else:
         batch_correction_wrapper.R
-        
         analyse "batch_correction"
         dataMatrix "$dataMatrix"
         sampleMetadata "$sampleMetadata"
@@ -49,12 +46,17 @@
     #end if
     dataMatrix_out "$dataMatrix_out" variableMetadata_out "$variableMetadata_out"
     graph_output "$graph_output"  rdata_output "$rdata_output"
+    batch_col_name "$batch_col_name" injection_order_col_name "$injection_order_col_name" sample_type_col_name "$sample_type_col_name"
   ]]></command>
 
 	<inputs>
 		<param name="dataMatrix" label="Data Matrix file " format="tabular" type="data" />
 		<param name="sampleMetadata" label="Sample metadata file " format="tabular" type="data" help="must contain at least the three following columns: 'batch' + 'injectionOrder' + 'sampleType'"/>
 		<param name="variableMetadata" label="Variable metadata file " format="tabular" type="data" />
+
+		<param name="batch_col_name" label="Batch column name" type="text" size="64" value="batch" help="The name of the column containing the batch values."/>
+		<param name="injection_order_col_name" label="Injection order column name" type="text" size="64" value="injectionOrder" help="The name of the column containing the injection order values."/>
+		<param name="sample_type_col_name" label="Sample type column name" type="text" size="64" value="sampleType" help="The name of the column containing the sample type values."/>
 		
 		<conditional name="span_condition">
 			<param name="method" label="Type of regression model " type="select" help="To select between linear or non-linear (lowess or loess) methods to be used in Van der Kloet algorithm ; when using loess, you can choose to use pools or samples to model batch effect.">


### PR DESCRIPTION
Now custom column names can be set into batch_correction. Hence MTBLS
studies can be used instead of preformated W4M TSV files.