### PR TITLE
Update container-isatab-create tag

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -291,7 +291,7 @@
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
       <param id="docker_image_override">isatab-create</param>
-      <param id="docker_tag_override">v0.9.5_cv0.3.6.36</param>
+      <param id="docker_tag_override">v0.9.5_cv0.3.6.37</param>
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>


### PR DESCRIPTION
Update container-isatab-create tag. Was `v0.9.5_cv0.3.6.36` (doesn't exist), should be `v0.9.5_cv0.3.6.37`.