### PR TITLE
Adds support for deploying on top of docker-galaxy-stable compose images

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "docker-galaxy-stable"]
+	path = docker-galaxy-stable
+	url = https://github.com/pcm32/docker-galaxy-stable
+	branch = feature/isatools_lite

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,10 +81,9 @@ ENV PYKUBE_KUBERNETES_SERVICE_HOST kubernetes
 # Galaxy tours which guide users through the subsequent steps in an analysis
 COPY config/plugins/tours/*.yaml config/plugins/tours/
 
-COPY html/partners.png \
-     html/PhenoMeNal_logo.png \
-     html/welcome.html \
-  static/
+COPY html/partners.png static/welcome_partners.png
+COPY html/PhenoMeNal_logo.png static/welcome_PhenoMeNal_logo.png
+COPY html/welcome.html static/
 
 COPY ansible ansible
 COPY workflows workflows

--- a/Dockerfile_init
+++ b/Dockerfile_init
@@ -1,0 +1,40 @@
+FROM pcm32/galaxy-init-pheno
+
+MAINTAINER PhenoMeNal-H2020 Project <phenomenal-h2020-users@googlegroups.com>
+
+LABEL Description="Galaxy 17.05-phenomenal for running inside Kubernetes."
+LABEL software="Galaxy Init"
+LABEL software.version="17.05-pheno-lr"
+LABEL version="1.3"
+
+#COPY config/galaxy.ini config/galaxy.ini
+COPY config/job_conf.xml config/job_conf.xml
+COPY config/tool_conf.xml config/tool_conf.xml
+COPY config/sanitize_whitelist.txt config/sanitize_whitelist.txt
+COPY tools/phenomenal tools/phenomenal
+
+# Reqs/limits
+COPY config/job_resource_params_conf.xml config/job_resource_params_conf.xml
+COPY config/phenomenal_tools2container.yaml config/phenomenal_tools2container.yaml
+COPY rules/k8s_destinations.py /galaxy-central/lib/galaxy/jobs/rules/k8s_destination.py
+
+# Galaxy tours which guide users through the subsequent steps in an analysis
+COPY config/plugins/tours/*.yaml config/plugins/tours/
+
+COPY html/partners.png welcome/welcome_partners.png
+COPY html/PhenoMeNal_logo.png welcome/welcome_PhenoMeNal_logo.png
+COPY html/welcome.html welcome/welcome.html
+
+COPY ansible ansible
+COPY workflows workflows_to_load
+COPY container-simple-checks.sh container-simple-checks.sh
+COPY test_cmds.txt test_cmds.txt
+COPY post-start-actions.sh post-start-actions.sh
+RUN chmod u+x post-start-actions.sh
+
+# Missing XCMS datatypes for w4m
+COPY external-datatypes/rdata_xcms_datatype.py /galaxy-central/lib/galaxy/datatypes/
+COPY external-datatypes/rdata_camera_datatype.py /galaxy-central/lib/galaxy/datatypes/
+COPY external-datatypes/no_unzip_datatypes.py /galaxy-central/lib/galaxy/datatypes/
+COPY external-datatypes/nmrml_datatype.py /galaxy-central/lib/galaxy/datatypes/
+COPY config/datatypes_conf.xml config/datatypes_conf.xml

--- a/Dockerfile_web
+++ b/Dockerfile_web
@@ -1,0 +1,21 @@
+FROM pcm32/galaxy-stable-k8s
+MAINTAINER PhenoMeNal-H2020 Project <phenomenal-h2020-users@googlegroups.com>
+
+LABEL Description="Galaxy 17.05-phenomenal for running inside Kubernetes."
+LABEL software="Galaxy"
+LABEL version="2.0"
+LABEL software.version="17.05-pheno-lr"
+
+COPY config/galaxy.ini /home/galaxy/config/galaxy.ini
+COPY config/job_conf.xml /home/galaxy/config/job_conf.xml
+COPY config/tool_conf.xml /home/galaxy/config/tool_conf.xml
+COPY config/sanitize_whitelist.txt /home/galaxy/config/sanitize_whitelist.txt
+COPY tools/phenomenal /home/galaxy/tools/phenomenal
+
+COPY html/partners.png /home/galaxy/web/partners.png
+COPY html/PhenoMeNal_logo.png /home/galaxy/web/PhenoMeNal_logo.png
+COPY html/welcome.html /home/galaxy/web/welcome.html
+COPY ansible /home/galaxy/ansible
+COPY workflows /home/galaxy/workflows
+COPY container-simple-checks.sh container-simple-checks.sh
+COPY test_cmds.txt test_cmds.txt

--- a/build_galaxy_stable_init_phenomenal.sh
+++ b/build_galaxy_stable_init_phenomenal.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -x -e
+
+ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
+ANSIBLE_RELEASE=86a127ae3aaaea125c8faa0271471106f2a4f889
+
+GALAXY_RELEASE=b7dc87e872c14878a929237b3cb6d8fe2c579e5d
+GALAXY_REPO=phnmnl/galaxy
+
+docker build --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t pcm32/galaxy-base-pheno ../docker-galaxy-stable/compose/galaxy-base/
+docker push pcm32/galaxy-base-pheno
+
+docker build --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE -t pcm32/galaxy-init-pheno ../docker-galaxy-stable/compose/galaxy-init/
+docker push pcm32/galaxy-init-pheno
+
+docker build -t pcm32/galaxy-init-pheno-flavoured -f Dockerfile_init .
+docker push pcm32/galaxy-init-pheno-flavoured
+
+docker build -t pcm32/galaxy-stable-k8s ../docker-galaxy-stable/compose/galaxy-k8s/
+docker push pcm32/galaxy-stable-k8s

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -297,7 +297,7 @@
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
       <param id="docker_image_override">isatab-create</param>
-      <param id="docker_tag_override">v0.9.5_cv0.3.6.36</param>
+      <param id="docker_tag_override">v0.9.5_cv0.3.6.37</param>
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -4,21 +4,27 @@
   <plugins>
     <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4"/>
     <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
-      <param id="k8s_use_service_account">true</param>
-      <param id="k8s_persistent_volume_claim_name">galaxy-pvc</param>
+      <param id="k8s_use_service_account" from_environ="GALAXY_RUNNERS_K8S_USE_SERVICE_ACCOUNT">true</param>
+      <param id="k8s_persistent_volume_claim_name" from_environ="GALAXY_RUNNERS_K8S_PERSISTENT_VOLUME_CLAIM_NAME">galaxy-pvc</param>
       <!-- The following mount path needs to be the initial part of the "file_path" and "new_file_path" paths
             set in universe_wsgi.ini (or equivalent general galaxy config file).  -->
-      <param id="k8s_persistent_volume_claim_mount_path">/opt/galaxy_data</param>
-      <param id="k8s_namespace">default</param>
-      <param id="k8s_supplemental_group_id">0</param>
-      <param id="k8s_fs_group_id">0</param>
-      <param id="k8s_pull_policy">IfNotPresent</param>
+      <param id="k8s_persistent_volume_claim_mount_path" from_environ="GALAXY_RUNNERS_K8S_PERSISTENT_VOLUME_CLAIM_MOUNT_PATH">/opt/galaxy_data</param>
+      <param id="k8s_namespace" from_environ="GALAXY_RUNNERS_K8S_NAMESPACE">default</param>
+      <param id="k8s_supplemental_group_id" from_environ="GALAXY_RUNNERS_K8S_SUPPLEMENTAL_GROUP_ID">0</param>
+      <param id="k8s_fs_group_id" from_environ="GALAXY_RUNNERS_K8S_FS_GROUP_ID">0</param>
+      <param id="k8s_pull_policy" from_environ="GALAXY_RUNNERS_K8S_PULL_POLICY">IfNotPresent</param>
       <!-- Allows pods to retry up to this number of times, before marking the Job as failed -->
-      <param id="k8s_pod_retrials">1</param>
+      <param id="k8s_pod_retrials" from_environ="GALAXY_RUNNERS_K8S_POD_RETRIALS">1</param>
     </plugin>
   </plugins>
-  <handlers>
-    <handler id="main"/>
+  <handlers default="handlers">
+    <!--         HANDLERS -->
+    <handler id="main" tags="handlers"/>
+    <!-- HANDLERS  -->
+    <!-- HANDLERS 
+    <handler id="handler0" tags="handlers"/>
+    <handler id="handler1" tags="handlers"/>
+         HANDLERS -->
   </handlers>
   <destinations default="local">
     <destination id="local" runner="local"/>

--- a/html/welcome.html
+++ b/html/welcome.html
@@ -77,14 +77,14 @@
 
     <div class="jumbotron" style="padding:0">
         <div class="container">
-            <img src="./PhenoMeNal_logo.png" width="30%" height="30%" />
+            <img src="./welcome_PhenoMeNal_logo.png" width="30%" height="30%" />
         </div>
     </div>
 
     <div class="container">
 
         <table class="center" width="768px">
-            <tr><td class="right" colspan="2"><small>PhenoMeNal <a target="_blank" href="https://github.com/phnmnl/phenomenal-h2020/wiki/Release-notes-2017-08">release 17.08</a>, based on Galaxy <a target="_blank" href="https://docs.galaxyproject.org/en/master/releases/17.05_announce.html">version 17.05</a></small></td></tr>
+            <tr><td class="right" colspan="2"><small>PhenoMeNal <a target="_blank" href="https://github.com/phnmnl/phenomenal-h2020/wiki/Release-notes-2017-08">release 17.10</a>, based on Galaxy <a target="_blank" href="https://docs.galaxyproject.org/en/master/releases/17.09_announce.html">version 17.09</a></small></td></tr>
             <tr>
                 <td>
                     <h2>Quickstart</h2>
@@ -120,7 +120,7 @@
             <hr class="thin">
             <div class="center">
 		        <a target="_blank" class="reference" href="http://phenomenal-h2020.eu/home/">PhenoMeNal</a> is funded by the European Commission's Horizon2020 programme, grant agreement number 654241. It is driven by a consortium of 14 European research groups with strong experience in tool and methods development for large data acquisition, integration and analysis for metabolic phenotypes, genome and cross-omics data.
-                <br/><br/><img src="./partners.png" width="90%" height="90%" />
+                <br/><br/><img src="./welcome_partners.png" width="90%" height="90%" />
 
                 <br>
 

--- a/post-start-actions.sh
+++ b/post-start-actions.sh
@@ -5,7 +5,6 @@ echo "Adding workflows to Galaxy for user $GALAXY_DEFAULT_ADMIN_USER from dir $W
 
 # Waits for the instance to be up and adds the workflows in a non-blocking fashion, so that tail below proceeds
 # uses ephemeris. Virtualenv needed while pre 0.8 versions of ephemeris are being used in other places
-deactivate
 virtualenv .ephemeris-publishable-workflow && \
   source .ephemeris-publishable-workflow/bin/activate && \
   apt-get update && apt-get install -y --no-install-recommends git && \

--- a/post-start-actions.sh
+++ b/post-start-actions.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Adding workflows to Galaxy for user $GALAXY_DEFAULT_ADMIN_USER from dir $WORKFLOWS_DIR"
+
+
+# Waits for the instance to be up and adds the workflows in a non-blocking fashion, so that tail below proceeds
+# uses ephemeris. Virtualenv needed while pre 0.8 versions of ephemeris are being used in other places
+deactivate
+virtualenv .ephemeris-publishable-workflow && \
+  source .ephemeris-publishable-workflow/bin/activate && \
+  apt-get update && apt-get install -y --no-install-recommends git && \
+  pip install -U pip && pip install -e git://github.com/galaxyproject/ephemeris.git@#egg=ephemeris && \
+  echo "...dependencies for workflows installed"
+  workflow-install -g http://127.0.0.1 -v -a $GALAXY_DEFAULT_ADMIN_KEY \
+      -w /export/workflows_to_load --publish_workflows && \
+  deactivate && \
+  apt-get purge -y git && \
+rm -rf .ephemeris-publishable-workflow

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -2,14 +2,15 @@
 #set -x -e
 
 ANSIBLE_REPO=pcm32/ansible-galaxy-extras
-ANSIBLE_RELEASE=ee6203507a5bdcf8301d1d09845f204fd4b4e185
+ANSIBLE_RELEASE=3f934a1e9c39c7d03278538bb9ea0ca196976f45
 
 TAG=isa_test
+#NO_CACHE="--no-cache"
 
 if [ -n $ANSIBLE_REPO ]
     then
        echo "Making custom galaxy-base-pheno:$TAG from $ANSIBLE_REPO at $ANSIBLE_RELEASE"
-       docker build --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t pcm32/galaxy-base-pheno:$TAG ../docker-galaxy-stable/compose/galaxy-base/
+       docker build $NO_CACHE --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t pcm32/galaxy-base-pheno:$TAG ../docker-galaxy-stable/compose/galaxy-base/
        docker push pcm32/galaxy-base-pheno:$TAG
 fi
 
@@ -27,7 +28,7 @@ if [ -n $GALAXY_REPO ]
 	      echo "Using FROM $FROM for galaxy init"
 	      DOCKERFILE_INIT_1=Dockerfile_init
        fi
-       docker build --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE --build-arg ISATOOLS_LITE_INSTALL=True -t pcm32/galaxy-init-pheno:$TAG -f ../docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 ../docker-galaxy-stable/compose/galaxy-init/
+       docker build $NO_CACHE --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE --build-arg ISATOOLS_LITE_INSTALL=True -t pcm32/galaxy-init-pheno:$TAG -f ../docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 ../docker-galaxy-stable/compose/galaxy-init/
        docker push pcm32/galaxy-init-pheno:$TAG
 fi
 
@@ -38,7 +39,7 @@ then
 	sed s+pcm32/galaxy-init-pheno$+pcm32/galaxy-init-pheno:$TAG+ Dockerfile_init > Dockerfile_init_tagged
 	DOCKERFILE_INIT_FLAVOUR=Dockerfile_init_tagged
 fi
-docker build -t pcm32/galaxy-init-pheno-flavoured:$TAG -f $DOCKERFILE_INIT_FLAVOUR .
+docker build $NO_CACHE -t pcm32/galaxy-init-pheno-flavoured:$TAG -f $DOCKERFILE_INIT_FLAVOUR .
 docker push pcm32/galaxy-init-pheno-flavoured:$TAG
 
 

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#set -x -e
+
+ANSIBLE_REPO=pcm32/ansible-galaxy-extras
+ANSIBLE_RELEASE=837193d5d0490261dc3c5bd5cd5627ce311dcef8
+
+TAG=wf_test
+
+if [ -n $ANSIBLE_REPO ]
+    then
+       echo "Making custom galaxy-base-pheno:$TAG from $ANSIBLE_REPO at $ANSIBLE_RELEASE"
+       docker build --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t pcm32/galaxy-base-pheno:$TAG ../docker-galaxy-stable/compose/galaxy-base/
+       docker push pcm32/galaxy-base-pheno:$TAG
+fi
+
+GALAXY_RELEASE=9a445ed999c1b168690e953d62038e79316f59d2
+GALAXY_REPO=phnmnl/galaxy
+
+if [ -n $GALAXY_REPO ]
+    then
+       echo "Making custom galaxy-init-pheno:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
+       DOCKERFILE_INIT_1=Dockerfile
+       if [ -n $ANSIBLE_REPO ]
+          then
+              sed s+quay.io/bgruening/galaxy-base:dev+pcm32/galaxy-base-pheno:$TAG+ ../docker-galaxy-stable/compose/galaxy-init/Dockerfile > ../docker-galaxy-stable/compose/galaxy-init/Dockerfile_init
+	      FROM=`grep ^FROM ../docker-galaxy-stable/compose/galaxy-init/Dockerfile_init | awk '{ print $2 }'`
+	      echo "Using FROM $FROM for galaxy init"
+	      DOCKERFILE_INIT_1=Dockerfile_init
+       fi
+       docker build --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE -t pcm32/galaxy-init-pheno:$TAG -f ../docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 ../docker-galaxy-stable/compose/galaxy-init/
+       docker push pcm32/galaxy-init-pheno:$TAG
+fi
+
+DOCKERFILE_INIT_FLAVOUR=Dockerfile_init
+if [ -n $GALAXY_REPO ]
+then
+	echo "Making custom galaxy-init-pheno-flavoured:$TAG starting from galaxy-init-pheno:$TAG"
+	sed s+pcm32/galaxy-init-pheno$+pcm32/galaxy-init-pheno:$TAG+ Dockerfile_init > Dockerfile_init_tagged
+	DOCKERFILE_INIT_FLAVOUR=Dockerfile_init_tagged
+fi
+docker build -t pcm32/galaxy-init-pheno-flavoured:$TAG -f $DOCKERFILE_INIT_FLAVOUR .
+docker push pcm32/galaxy-init-pheno-flavoured:$TAG
+
+
+DOCKERFILE_WEB=Dockerfile
+if [ -n $GALAXY_REPO ]
+then
+	echo "Making custom galaxy-web-k8s:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
+	sed s+quay.io/bgruening/galaxy-base:dev+pcm32/galaxy-base-pheno:$TAG+ ../docker-galaxy-stable/compose/galaxy-web/Dockerfile > ../docker-galaxy-stable/compose/galaxy-web/Dockerfile_web
+	DOCKERFILE_WEB=Dockerfile_web
+fi
+docker build --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8,k8s -t pcm32/galaxy-web-k8s:$TAG -f ../docker-galaxy-stable/compose/galaxy-web/$DOCKERFILE_WEB ../docker-galaxy-stable/compose/galaxy-web/
+docker push pcm32/galaxy-web-k8s:$TAG
+
+echo "Relevant containers:"
+echo "Web:          pcm32/galaxy-web-k8s:$TAG"
+echo "Init Flavour: pcm32/galaxy-init-pheno-flavoured:$TAG"

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -1,17 +1,29 @@
 #!/bin/bash
-#set -x -e
+set -e
+
+DOCKER_REPO=${CONTAINER_REGISTRY+/:-}
+DOCKER_USER=${CONTAINER_USER:-pcm32}
 
 ANSIBLE_REPO=pcm32/ansible-galaxy-extras
 ANSIBLE_RELEASE=3f934a1e9c39c7d03278538bb9ea0ca196976f45
 
-TAG=isa_test
+TAG=v17.09_cerebellin
 #NO_CACHE="--no-cache"
+
+if [[ ! -z ${CONTAINER_TAG_PREFIX+x} ]];
+then
+	if [[ ! -z ${BUILD_NUMBER+x} ]]; 
+	then
+            TAG=${CONTAINER_TAG_PREFIX}.${BUILD_NUMBER}
+        fi
+fi
+
 
 if [ -n $ANSIBLE_REPO ]
     then
        echo "Making custom galaxy-base-pheno:$TAG from $ANSIBLE_REPO at $ANSIBLE_RELEASE"
-       docker build $NO_CACHE --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t pcm32/galaxy-base-pheno:$TAG ../docker-galaxy-stable/compose/galaxy-base/
-       docker push pcm32/galaxy-base-pheno:$TAG
+       docker build $NO_CACHE --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG docker-galaxy-stable/compose/galaxy-base/
+       docker push $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG
 fi
 
 GALAXY_RELEASE=9a445ed999c1b168690e953d62038e79316f59d2
@@ -23,36 +35,36 @@ if [ -n $GALAXY_REPO ]
        DOCKERFILE_INIT_1=Dockerfile
        if [ -n $ANSIBLE_REPO ]
           then
-              sed s+quay.io/bgruening/galaxy-base:dev+pcm32/galaxy-base-pheno:$TAG+ ../docker-galaxy-stable/compose/galaxy-init/Dockerfile > ../docker-galaxy-stable/compose/galaxy-init/Dockerfile_init
+              sed s+quay.io/bgruening/galaxy-base:dev+$DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG+ docker-galaxy-stable/compose/galaxy-init/Dockerfile > docker-galaxy-stable/compose/galaxy-init/Dockerfile_init
 	      FROM=`grep ^FROM ../docker-galaxy-stable/compose/galaxy-init/Dockerfile_init | awk '{ print $2 }'`
 	      echo "Using FROM $FROM for galaxy init"
 	      DOCKERFILE_INIT_1=Dockerfile_init
        fi
-       docker build $NO_CACHE --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE --build-arg ISATOOLS_LITE_INSTALL=True -t pcm32/galaxy-init-pheno:$TAG -f ../docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 ../docker-galaxy-stable/compose/galaxy-init/
-       docker push pcm32/galaxy-init-pheno:$TAG
+       docker build $NO_CACHE --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE --build-arg ISATOOLS_LITE_INSTALL=True -t $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG -f docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 docker-galaxy-stable/compose/galaxy-init/
+       docker push $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG
 fi
 
 DOCKERFILE_INIT_FLAVOUR=Dockerfile_init
 if [ -n $GALAXY_REPO ]
 then
 	echo "Making custom galaxy-init-pheno-flavoured:$TAG starting from galaxy-init-pheno:$TAG"
-	sed s+pcm32/galaxy-init-pheno$+pcm32/galaxy-init-pheno:$TAG+ Dockerfile_init > Dockerfile_init_tagged
+	sed s+pcm32/galaxy-init-pheno$+$DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG+ Dockerfile_init > Dockerfile_init_tagged
 	DOCKERFILE_INIT_FLAVOUR=Dockerfile_init_tagged
 fi
-docker build $NO_CACHE -t pcm32/galaxy-init-pheno-flavoured:$TAG -f $DOCKERFILE_INIT_FLAVOUR .
-docker push pcm32/galaxy-init-pheno-flavoured:$TAG
+docker build $NO_CACHE -t $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno-flavoured:$TAG -f $DOCKERFILE_INIT_FLAVOUR .
+docker push $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno-flavoured:$TAG
 
 
 DOCKERFILE_WEB=Dockerfile
 if [ -n $GALAXY_REPO ]
 then
 	echo "Making custom galaxy-web-k8s:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
-	sed s+quay.io/bgruening/galaxy-base:dev+pcm32/galaxy-base-pheno:$TAG+ ../docker-galaxy-stable/compose/galaxy-web/Dockerfile > ../docker-galaxy-stable/compose/galaxy-web/Dockerfile_web
+	sed s+quay.io/bgruening/galaxy-base:dev+$DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG+ docker-galaxy-stable/compose/galaxy-web/Dockerfile > docker-galaxy-stable/compose/galaxy-web/Dockerfile_web
 	DOCKERFILE_WEB=Dockerfile_web
 fi
-docker build --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8,k8s -t pcm32/galaxy-web-k8s:$TAG -f ../docker-galaxy-stable/compose/galaxy-web/$DOCKERFILE_WEB ../docker-galaxy-stable/compose/galaxy-web/
-docker push pcm32/galaxy-web-k8s:$TAG
+docker build --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8,k8s -t $DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG -f docker-galaxy-stable/compose/galaxy-web/$DOCKERFILE_WEB docker-galaxy-stable/compose/galaxy-web/
+docker push $DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG
 
 echo "Relevant containers:"
-echo "Web:          pcm32/galaxy-web-k8s:$TAG"
-echo "Init Flavour: pcm32/galaxy-init-pheno-flavoured:$TAG"
+echo "Web:          $DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG"
+echo "Init Flavour: $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno-flavoured:$TAG"

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -2,9 +2,9 @@
 #set -x -e
 
 ANSIBLE_REPO=pcm32/ansible-galaxy-extras
-ANSIBLE_RELEASE=837193d5d0490261dc3c5bd5cd5627ce311dcef8
+ANSIBLE_RELEASE=ee6203507a5bdcf8301d1d09845f204fd4b4e185
 
-TAG=wf_test
+TAG=isa_test
 
 if [ -n $ANSIBLE_REPO ]
     then
@@ -27,7 +27,7 @@ if [ -n $GALAXY_REPO ]
 	      echo "Using FROM $FROM for galaxy init"
 	      DOCKERFILE_INIT_1=Dockerfile_init
        fi
-       docker build --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE -t pcm32/galaxy-init-pheno:$TAG -f ../docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 ../docker-galaxy-stable/compose/galaxy-init/
+       docker build --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE --build-arg ISATOOLS_LITE_INSTALL=True -t pcm32/galaxy-init-pheno:$TAG -f ../docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 ../docker-galaxy-stable/compose/galaxy-init/
        docker push pcm32/galaxy-init-pheno:$TAG
 fi
 


### PR DESCRIPTION
This PR introduces the ability to run the PhenoMeNal setup on top of the docker galaxy stable community images, which solves performance bottlenecks at the Galaxy UI side, brings automatics FTP upload support and includes all the features of our current setup (user addition, workflow addition, etc.). This will be twinned with a new Galaxy helm chart which has been used with this for some months during testing.

This has been currently working without issues at http://193.62.52.92:30700/, and was battle tested for performance with many users at the EMBO Metabolomics Course last week.

This should be used with https://github.com/galaxyproject/galaxy-kubernetes/tree/feature/sync_with_galaxy_stable/galaxy-stable
