### PR TITLE
Sets Galaxy release to standard PhenoMeNal one, and ansible release t…

### DIFF
--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -14,9 +14,9 @@ fi
     
 
 ANSIBLE_REPO=pcm32/ansible-galaxy-extras
-ANSIBLE_RELEASE=032a82fb733698609a03e4be438d6aa016a1284a
+ANSIBLE_RELEASE=9947401f95285623ce74d8e32ef3a47898c80329
 
-TAG=v17.09_cerebellin
+TAG=v17.09_cerebellin-isafix
 #NO_CACHE="--no-cache"
 
 if [[ ! -z ${CONTAINER_TAG_PREFIX+x} ]];
@@ -35,7 +35,7 @@ if [ -n $ANSIBLE_REPO ]
        docker push $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG
 fi
 
-GALAXY_RELEASE=9a445ed999c1b168690e953d62038e79316f59d2
+GALAXY_RELEASE=release_17.09_plus_isa_k8s_resource_limts
 GALAXY_REPO=phnmnl/galaxy
 
 if [ -n $GALAXY_REPO ]

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -4,6 +4,8 @@ set -e
 DOCKER_REPO=${CONTAINER_REGISTRY:-}
 DOCKER_USER=${CONTAINER_USER:-pcm32}
 
+#PUSH_INTERMEDIATE_IMAGES=yes
+
 if [[ ${#DOCKER_REPO} > 0 ]];
 then
     if [[ ! "$DOCKER_REPO" == */ ]];
@@ -14,9 +16,9 @@ fi
     
 
 ANSIBLE_REPO=pcm32/ansible-galaxy-extras
-ANSIBLE_RELEASE=9947401f95285623ce74d8e32ef3a47898c80329
+ANSIBLE_RELEASE=17.09-pheno-cerebellin
 
-TAG=v17.09_cerebellin-isafix
+TAG=v17.09_cerebellin
 #NO_CACHE="--no-cache"
 
 if [[ ! -z ${CONTAINER_TAG_PREFIX+x} ]];
@@ -32,7 +34,11 @@ if [ -n $ANSIBLE_REPO ]
     then
        echo "Making custom galaxy-base-pheno:$TAG from $ANSIBLE_REPO at $ANSIBLE_RELEASE"
        docker build $NO_CACHE --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG docker-galaxy-stable/compose/galaxy-base/
-       docker push $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG
+       if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES+x} ]];
+       then
+	   echo "Pushing intermediate image $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG"
+           docker push $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG
+       fi
 fi
 
 GALAXY_RELEASE=release_17.09_plus_isa_k8s_resource_limts
@@ -50,7 +56,11 @@ if [ -n $GALAXY_REPO ]
 	      DOCKERFILE_INIT_1=Dockerfile_init
        fi
        docker build $NO_CACHE --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE --build-arg ISATOOLS_LITE_INSTALL=True -t $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG -f docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 docker-galaxy-stable/compose/galaxy-init/
-       docker push $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG
+       if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES+x} ]];
+       then
+	   echo "Pushing intermediate image $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG"
+           docker push $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG
+       fi
 fi
 
 DOCKERFILE_INIT_FLAVOUR=Dockerfile_init

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -4,6 +4,7 @@ set -e
 DOCKER_REPO=${CONTAINER_REGISTRY:-}
 DOCKER_USER=${CONTAINER_USER:-pcm32}
 
+# Uncomment to push intermediate images, otherwise only the images needed for the helm chart are pushed.
 #PUSH_INTERMEDIATE_IMAGES=yes
 
 if [[ ${#DOCKER_REPO} > 0 ]];
@@ -19,6 +20,7 @@ ANSIBLE_REPO=pcm32/ansible-galaxy-extras
 ANSIBLE_RELEASE=17.09-pheno-cerebellin
 
 TAG=v17.09_cerebellin
+# Uncomment to avoid using the cache when building docker images.
 #NO_CACHE="--no-cache"
 
 if [[ ! -z ${CONTAINER_TAG_PREFIX+x} ]];
@@ -30,19 +32,23 @@ then
 fi
 
 
+GALAXY_BASE_PHENO_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG
+
 if [ -n $ANSIBLE_REPO ]
     then
        echo "Making custom galaxy-base-pheno:$TAG from $ANSIBLE_REPO at $ANSIBLE_RELEASE"
-       docker build $NO_CACHE --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG docker-galaxy-stable/compose/galaxy-base/
+       docker build $NO_CACHE --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t $GALAXY_BASE_PHENO_TAG docker-galaxy-stable/compose/galaxy-base/
        if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES+x} ]];
        then
 	   echo "Pushing intermediate image $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG"
-           docker push $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG
+           docker push $GALAXY_BASE_PHENO_TAG
        fi
 fi
 
 GALAXY_RELEASE=release_17.09_plus_isa_k8s_resource_limts
 GALAXY_REPO=phnmnl/galaxy
+
+GALAXY_INIT_PHENO_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG
 
 if [ -n $GALAXY_REPO ]
     then
@@ -50,40 +56,43 @@ if [ -n $GALAXY_REPO ]
        DOCKERFILE_INIT_1=Dockerfile
        if [ -n $ANSIBLE_REPO ]
           then
-              sed s+quay.io/bgruening/galaxy-base:dev+$DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG+ docker-galaxy-stable/compose/galaxy-init/Dockerfile > docker-galaxy-stable/compose/galaxy-init/Dockerfile_init
+              sed s+quay.io/bgruening/galaxy-base:dev+$GALAXY_BASE_PHENO_TAG+ docker-galaxy-stable/compose/galaxy-init/Dockerfile > docker-galaxy-stable/compose/galaxy-init/Dockerfile_init
 	      FROM=`grep ^FROM ../docker-galaxy-stable/compose/galaxy-init/Dockerfile_init | awk '{ print $2 }'`
 	      echo "Using FROM $FROM for galaxy init"
 	      DOCKERFILE_INIT_1=Dockerfile_init
        fi
-       docker build $NO_CACHE --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE --build-arg ISATOOLS_LITE_INSTALL=True -t $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG -f docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 docker-galaxy-stable/compose/galaxy-init/
+       docker build $NO_CACHE --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE --build-arg ISATOOLS_LITE_INSTALL=True -t $GALAXY_INIT_PHENO_TAG -f docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 docker-galaxy-stable/compose/galaxy-init/
        if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES+x} ]];
        then
-	   echo "Pushing intermediate image $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG"
-           docker push $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG
+	   echo "Pushing intermediate image $GALAXY_INIT_PHENO_TAG"
+           docker push $GALAXY_INIT_PHENO_TAG
        fi
 fi
+
+GALAXY_INIT_PHENO_FLAVOURED_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init-pheno-flavoured:$TAG
 
 DOCKERFILE_INIT_FLAVOUR=Dockerfile_init
 if [ -n $GALAXY_REPO ]
 then
 	echo "Making custom galaxy-init-pheno-flavoured:$TAG starting from galaxy-init-pheno:$TAG"
-	sed s+pcm32/galaxy-init-pheno$+$DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG+ Dockerfile_init > Dockerfile_init_tagged
+	sed s+pcm32/galaxy-init-pheno$+$GALAXY_INIT_PHENO_TAG+ Dockerfile_init > Dockerfile_init_tagged
 	DOCKERFILE_INIT_FLAVOUR=Dockerfile_init_tagged
 fi
-docker build $NO_CACHE -t $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno-flavoured:$TAG -f $DOCKERFILE_INIT_FLAVOUR .
-docker push $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno-flavoured:$TAG
+docker build $NO_CACHE -t $GALAXY_INIT_PHENO_FLAVOURED_TAG -f $DOCKERFILE_INIT_FLAVOUR .
+docker push $GALAXY_INIT_PHENO_FLAVOURED_TAG 
 
+GALAXY_WEB_K8S_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG
 
 DOCKERFILE_WEB=Dockerfile
 if [ -n $GALAXY_REPO ]
 then
 	echo "Making custom galaxy-web-k8s:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
-	sed s+quay.io/bgruening/galaxy-base:dev+$DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG+ docker-galaxy-stable/compose/galaxy-web/Dockerfile > docker-galaxy-stable/compose/galaxy-web/Dockerfile_web
+	sed s+quay.io/bgruening/galaxy-base:dev+$GALAXY_BASE_PHENO_TAG+ docker-galaxy-stable/compose/galaxy-web/Dockerfile > docker-galaxy-stable/compose/galaxy-web/Dockerfile_web
 	DOCKERFILE_WEB=Dockerfile_web
 fi
-docker build --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8,k8s -t $DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG -f docker-galaxy-stable/compose/galaxy-web/$DOCKERFILE_WEB docker-galaxy-stable/compose/galaxy-web/
-docker push $DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG
+docker build --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8,k8s -t $GALAXY_WEB_K8S_TAG -f docker-galaxy-stable/compose/galaxy-web/$DOCKERFILE_WEB docker-galaxy-stable/compose/galaxy-web/
+docker push $GALAXY_WEB_K8S_TAG
 
 echo "Relevant containers:"
-echo "Web:          $DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG"
-echo "Init Flavour: $DOCKER_REPO$DOCKER_USER/galaxy-init-pheno-flavoured:$TAG"
+echo "Web:          $GALAXY_WEB_K8S_TAG"
+echo "Init Flavour: $GALAXY_INIT_PHENO_FLAVOURED_TAG"


### PR DESCRIPTION
Updates for the Galaxy setup on community images, to use our current Galaxy version for cerebellin and simplified isatools, including fix to avoid errors on file uploads.

Tested on 193.62.52.92:30700.