### PR TITLE
First working version of mzml2isa/nmrml2isa with isa-tab datatype

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -149,14 +149,6 @@
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>
-    <destination id="nmrml2isa-container" runner="k8s">
-      <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
-      <param id="docker_owner_override">phnmnl</param>
-      <param id="docker_image_override">nmrml2isa</param>
-      <param id="docker_tag_override">v0.3.0_cv0.1.10</param>
-      <param id="max_pod_retrials">3</param>
-      <param id="docker_enabled">true</param>
-    </destination>
     <destination id="mtbls-downloader-container" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
@@ -344,7 +336,7 @@
     <tool id="soap_opls" destination="soap-nmr-container"/>
     <!-- other NMR -->
     <tool id="mzml2isa" destination="dynamic-k8s-small" resources="all"/>
-    <tool id="nmrml2isa" destination="nmrml2isa-container"/>
+    <tool id="nmrml2isa" destination="dynamic-k8s-small" resources="all"/>
     <tool id="mtbls-downloader" destination="mtbls-downloader-container"/>
     <tool id="mtbls-labs-uploader" destination="mtbls-labs-uploader-container"/>
     <tool id="metfragcli" destination="metfrag-cli-container"/>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -149,14 +149,6 @@
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>
-    <destination id="mzml2isa-container" runner="k8s">
-      <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
-      <param id="docker_owner_override">phnmnl</param>
-      <param id="docker_image_override">mzml2isa</param>
-      <param id="docker_tag_override">v0.4.28_cv0.2.23</param>
-      <param id="max_pod_retrials">3</param>
-      <param id="docker_enabled">true</param>
-    </destination>
     <destination id="nmrml2isa-container" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
@@ -351,7 +343,7 @@
     <tool id="soap_process" destination="soap-nmr-container"/>
     <tool id="soap_opls" destination="soap-nmr-container"/>
     <!-- other NMR -->
-    <tool id="mzml2isa" destination="mzml2isa-container"/>
+    <tool id="mzml2isa" destination="dynamic-k8s-small" resources="all"/>
     <tool id="nmrml2isa" destination="nmrml2isa-container"/>
     <tool id="mtbls-downloader" destination="mtbls-downloader-container"/>
     <tool id="mtbls-labs-uploader" destination="mtbls-labs-uploader-container"/>

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -387,7 +387,7 @@ assignment:
 - docker_image_override: mzml2isa
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu
-  docker_tag_override: v0.4.28_cv0.2.23
+  docker_tag_override: v0.4.28_cv0.3.26 
   max_pod_retrials: 3
   tools_id:
   - mzml2isa

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -345,7 +345,7 @@ assignment:
 - docker_image_override: nmrml2isa
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu
-  docker_tag_override: v0.3.0_cv0.1.10
+  docker_tag_override: v0.3.0_cv0.2.12 
   max_pod_retrials: 3
   tools_id:
   - nmrml2isa

--- a/tools/phenomenal/ms/mzml2isa/mzml2isa.xml
+++ b/tools/phenomenal/ms/mzml2isa/mzml2isa.xml
@@ -189,7 +189,7 @@
 	       mv output-dir/'$name_of_study'/* '$isastudy.files_path'/;
    #if $include_raw_data_in_output:
 	 #if $data_file.input == "zip_file":
-               unzip "$data_file.zip_input" -d "$isastudy.files_path";
+               unzip -j "$data_file.zip_input" -d "$isastudy.files_path";
 	 #else
                tar -xf "$data_file.tar_input" -C "$isastudy.files_path";
 	 #end if       
@@ -237,7 +237,7 @@ Notes:
 		<discover_datasets pattern="(?P&lt;designation&gt;s_.+)\.txt" directory="study_dir" format="tabular"/>
 	</collection>
 	<data name="i_file" format="tabular" label="I File" from_work_dir="study_dir/i_Investigation.txt" visible="true"/>
-        <data name="isastudy" label="${name_of_study}" format="isa-tab"/>
+        <data name="isastudy" label="${name_of_study} ISA Archive" format="isa-tab"/>
     </outputs>
     <tests>
         <test>

--- a/tools/phenomenal/ms/mzml2isa/mzml2isa.xml
+++ b/tools/phenomenal/ms/mzml2isa/mzml2isa.xml
@@ -187,11 +187,14 @@
 	       cd ../../;
                mkdir -p '$isastudy.files_path';
 	       mv output-dir/'$name_of_study'/* '$isastudy.files_path'/;
+   #if $include_raw_data_in_output:
 	 #if $data_file.input == "zip_file":
-               # unzip "$data_file.zip_input" -d "$isastudy.files_path";
+               unzip "$data_file.zip_input" -d "$isastudy.files_path";
 	 #else
-               # tar -xf "$data_file.tar_input" -C "$isastudy.files_path";
-         #end if       
+               tar -xf "$data_file.tar_input" -C "$isastudy.files_path";
+	 #end if       
+   #end if
+
 	       ]]>
     </command>
 
@@ -209,7 +212,8 @@
 		<param format="tar" name="tar_input" type="data" label="mzML TAR file"  help="A tarred folder of mzML files"/>
 	    </when>
         </conditional>
-        <param optional="true" format="txt" name="jsontxt" type="data" label="Additional user Metadata in json"  help="A user can add additional metadata directory through a json file"/>
+	<param optional="true" format="txt" name="jsontxt" type="data" label="Additional user Metadata in json"  help="A user can add additional metadata directory through a json file"/>
+	<param optiona="false" type="boolean" name="include_raw_data_in_output" checked="false" label="Include provided raw data in the ISA Archive" help="Set to 'Yes' to include the raw data. Including the original data in the ISA archive created will mean that the data will be copied, duplicating it in the server. If your quota is low, the dataset is really massive or you don't plan to process this ISA archive directly by another tool, you might want to avoid this."/>
         <expand macro="studymacro"/>
         <expand macro="investmacro"/>
         <expand macro="expmacro"/>

--- a/tools/phenomenal/ms/mzml2isa/mzml2isa.xml
+++ b/tools/phenomenal/ms/mzml2isa/mzml2isa.xml
@@ -1,4 +1,4 @@
-<tool id="mzml2isa" name="mzml2isa" version="0.1.0">
+<tool id="mzml2isa" name="mzml2isa" version="1.0.0">
     <description>Parser to get meta information from mzML files and create an ISA-Tab structure</description>
     
     <macros>
@@ -131,8 +131,8 @@
                -inputzip "$data_file.tar_input"
     #end if
                -jsontxt "$jsontxt"
-               -html_file "$html_file"
-	       -out_dir "$html_file.extra_files_path"
+               -html_file file.html
+	       -out_dir output-dir
 	       -study_title "$name_of_study"
                --s_submission_date "$s_submission_date"
                --s_release_date "$s_release_date"
@@ -178,10 +178,20 @@
                --organism_part_ref "$organism_part_ref"
 	       --organism_part_iri "$organism_part_iri";
 
-	       ln -s '$html_file.extra_files_path/$name_of_study' study_dir;
-
-	       cd study_dir;
+	       mkdir -p study_dir;
+	       cd output-dir/'$name_of_study';
 	       zip isa.zip i_* a_* s_* && mv isa.zip "$ISA_zip";
+	       cp i_* ../../study_dir/;
+	       cp a_* ../../study_dir/;
+	       cp s_* ../../study_dir/;
+	       cd ../../;
+               mkdir -p '$isastudy.files_path';
+	       mv output-dir/'$name_of_study'/* '$isastudy.files_path'/;
+	 #if $data_file.input == "zip_file":
+               # unzip "$data_file.zip_input" -d "$isastudy.files_path";
+	 #else
+               # tar -xf "$data_file.tar_input" -C "$isastudy.files_path";
+         #end if       
 	       ]]>
     </command>
 
@@ -214,7 +224,7 @@ Notes:
 - Single s_ as per mzml2isa definition (ISA does allow more than one s_ file).
 - Single i_ file.
 --> 
-        <data format="html" name="html_file" label="" />
+	<!-- <data format="html" name="html_file" label="" /> -->
         <data name="ISA_zip" format="zip" label="ISA Zip file"/>
           <collection type="list" label="A Files" name="a_files">
 		<discover_datasets pattern="(?P&lt;designation&gt;a_.+)\.txt" directory="study_dir" format="tabular"/>
@@ -223,6 +233,7 @@ Notes:
 		<discover_datasets pattern="(?P&lt;designation&gt;s_.+)\.txt" directory="study_dir" format="tabular"/>
 	</collection>
 	<data name="i_file" format="tabular" label="I File" from_work_dir="study_dir/i_Investigation.txt" visible="true"/>
+        <data name="isastudy" label="${name_of_study}" format="isa-tab"/>
     </outputs>
     <tests>
         <test>

--- a/tools/phenomenal/ms/mzml2isa/mzml2isa.xml
+++ b/tools/phenomenal/ms/mzml2isa/mzml2isa.xml
@@ -1,4 +1,4 @@
-<tool id="mzml2isa" name="mzml2isa" version="1.0.0">
+<tool id="mzml2isa" name="mzml2isa" version="2.0.0">
     <description>Parser to get meta information from mzML files and create an ISA-Tab structure</description>
     
     <macros>

--- a/tools/phenomenal/ms/mzml2isa/mzml2isa.xml
+++ b/tools/phenomenal/ms/mzml2isa/mzml2isa.xml
@@ -206,7 +206,7 @@
                 <option value="tar_file">TAR file from your history containing your mzML files</option>
             </param>
             <when value="zip_file">
-		<param format="zip" name="zip_input" type="data" label="mzML zip file"  help="A zipped folder of mzML files"/>
+		<param format="zip" name="zip_input" type="data" label="mzML zip file"  help="A zipped folder of mzML files. Any directory structure will be ignored and mzML files simply considered to be at the base of the ISA archive."/>
 	    </when>
             <when value="tar_file">
 		<param format="tar" name="tar_input" type="data" label="mzML TAR file"  help="A tarred folder of mzML files"/>

--- a/tools/phenomenal/nmr/nmrml2isa/nmrml2isa.xml
+++ b/tools/phenomenal/nmr/nmrml2isa/nmrml2isa.xml
@@ -1,4 +1,4 @@
-<tool id="nmrml2isa" name="nmrml2isa" version="0.1.0">
+<tool id="nmrml2isa" name="nmrml2isa" version="1.0.0">
     <description>Parser to get meta information from nmrML files and create an ISA-Tab structure</description>
     
     <macros>

--- a/tools/phenomenal/nmr/nmrml2isa/nmrml2isa.xml
+++ b/tools/phenomenal/nmr/nmrml2isa/nmrml2isa.xml
@@ -183,11 +183,7 @@
                mkdir -p '$isastudy.files_path';
 	       mv output-dir/'$name_of_study'/* '$isastudy.files_path'/;
    #if $include_raw_data_in_output:
-	 #if $data_file.input == "zip_file":
-               unzip -j "$data_file.zip_input" -d "$isastudy.files_path";
-	 #else
-               tar -xf "$data_file.tar_input" -C "$isastudy.files_path";
-	 #end if       
+               unzip -j "$inputzip" -d "$isastudy.files_path";
    #end if
 
                ]]>

--- a/tools/phenomenal/nmr/nmrml2isa/nmrml2isa.xml
+++ b/tools/phenomenal/nmr/nmrml2isa/nmrml2isa.xml
@@ -126,8 +126,8 @@
 
     wrapper.py -inputzip "$inputzip"
                -jsontxt "$jsontxt"
-               -html_file "$html_file"
-               -out_dir .
+               -html_file file.html
+               -out_dir output-dir
                -study_title "$name_of_study"
                --s_submission_date "$s_submission_date"
                --s_release_date "$s_release_date"
@@ -173,17 +173,31 @@
                --organism_part_ref "$organism_part_ref"
                --organism_part_iri "$organism_part_iri";
 
-               ln -s ./"$name_of_study" study_dir;
+               mkdir -p study_dir;
+	       cd output-dir/'$name_of_study';
+	       zip isa.zip i_* a_* s_* && mv isa.zip "$ISA_zip";
+	       cp i_* ../../study_dir/;
+	       cp a_* ../../study_dir/;
+	       cp s_* ../../study_dir/;
+	       cd ../../;
+               mkdir -p '$isastudy.files_path';
+	       mv output-dir/'$name_of_study'/* '$isastudy.files_path'/;
+   #if $include_raw_data_in_output:
+	 #if $data_file.input == "zip_file":
+               unzip -j "$data_file.zip_input" -d "$isastudy.files_path";
+	 #else
+               tar -xf "$data_file.tar_input" -C "$isastudy.files_path";
+	 #end if       
+   #end if
 
-               cd study_dir;
-               zip isa.zip i_* a_* s_* && mv isa.zip "$ISA_zip";
                ]]>
     </command>
 
     <inputs>
         <param name="name_of_study" type="text" label="Name study" help="This should not contain any spaces as the name will be used a prefix for ISA-tab file names" />
         <param format="zip" name="inputzip" type="data" label="nmrML zip file"  help="A zipped folder of nmrML files"/>
-        <param optional="true" format="txt" name="jsontxt" type="data" label="Additional user Metadata in json"  help="A user can add additional metadata directory through a json see link for example format"/>
+	<param optional="true" format="txt" name="jsontxt" type="data" label="Additional user Metadata in json"  help="A user can add additional metadata directory through a json see link for example format"/>
+	<param optiona="false" type="boolean" name="include_raw_data_in_output" checked="false" label="Include provided raw data in the ISA Archive" help="Set to 'Yes' to include the raw data. Including the original data in the ISA archive created will mean that the data will be copied, duplicating it in the server. If your quota is low, the dataset is really massive or you don't plan to process this ISA archive directly by another tool, you might want to avoid this."/>
         <expand macro="studymacro"/>
         <expand macro="investmacro"/>
         <expand macro="expmacro"/>
@@ -203,7 +217,7 @@ this would require changing the out_dir for wrapper.py back to $html_file.extra_
 'wrapper.py -out_dir $html_file.extra_files_path'
 
 -->
-    <data format="html" name="html_file" label="" hidden="true" />
+    <!-- <data format="html" name="html_file" label="" hidden="true" /> -->
     <data name="ISA_zip" format="zip" label="ISA Zip file"/>
         <collection type="list" label="A Files" name="a_files">
             <discover_datasets pattern="(?P&lt;designation&gt;a_.+)\.txt" directory="study_dir" format="tabular"/>
@@ -211,7 +225,8 @@ this would require changing the out_dir for wrapper.py back to $html_file.extra_
         <collection type="list" label="S Files" name="s_files">
             <discover_datasets pattern="(?P&lt;designation&gt;s_.+)\.txt" directory="study_dir" format="tabular"/>
         </collection>
-        <data name="i_file" format="tabular" label="I File" from_work_dir="study_dir/i_Investigation.txt" visible="true"/>
+	<data name="i_file" format="tabular" label="I File" from_work_dir="study_dir/i_Investigation.txt" visible="true"/>
+	<data name="isastudy" label="${name_of_study} ISA Archive" format="isa-tab"/>
     </outputs>
     <tests>
         <test>

--- a/tools/phenomenal/nmr/nmrml2isa/nmrml2isa.xml
+++ b/tools/phenomenal/nmr/nmrml2isa/nmrml2isa.xml
@@ -191,7 +191,7 @@
 
     <inputs>
         <param name="name_of_study" type="text" label="Name study" help="This should not contain any spaces as the name will be used a prefix for ISA-tab file names" />
-        <param format="zip" name="inputzip" type="data" label="nmrML zip file"  help="A zipped folder of nmrML files"/>
+        <param format="zip" name="inputzip" type="data" label="nmrML zip file"  help="A zipped folder of nmrML files. Any directory structure will be ignored and nmrML files simply considered to be at the base of the ISA archive."/>
 	<param optional="true" format="txt" name="jsontxt" type="data" label="Additional user Metadata in json"  help="A user can add additional metadata directory through a json see link for example format"/>
 	<param optiona="false" type="boolean" name="include_raw_data_in_output" checked="false" label="Include provided raw data in the ISA Archive" help="Set to 'Yes' to include the raw data. Including the original data in the ISA archive created will mean that the data will be copied, duplicating it in the server. If your quota is low, the dataset is really massive or you don't plan to process this ISA archive directly by another tool, you might want to avoid this."/>
         <expand macro="studymacro"/>


### PR DESCRIPTION
This PR introduces the use of isa-tab datatype as the main result format for mzml2isa. Currently only missing to add the raw data on the isa-tab archive created, I wonder if we should actually do this, as currently the result of the tool were only the I, S, A files. Adding data means we duplicate the data on the server (unless that we do some hard linking I guess).

@djcomlab @proccaserra @sneumann @pkrog @ilveroluca what do you think?