### PR TITLE
Tidy up job_conf and tool_conf to avoid latests and dev tags

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -78,7 +78,7 @@
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
       <param id="docker_image_override">camera</param>
-      <param id="docker_tag_override">latest</param>
+      <param id="docker_tag_override">v1.33.3_cv0.10.59</param>
       <param id="max_pod_retrials">1</param>
       <param id="docker_enabled">true</param>
     </destination>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -241,14 +241,6 @@
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>
-    <destination id="container-openms" runner="k8s">
-      <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
-      <param id="docker_owner_override">phnmnl</param>
-      <param id="docker_image_override">openms</param>
-      <param id="docker_tag_override">v2.1.0_cv0.2.15</param>
-      <param id="max_pod_retrials">3</param>
-      <param id="docker_enabled">true</param>
-    </destination>
     <destination id="container-json2isatab" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
@@ -343,99 +335,99 @@
     <tool id="camera-prepareoutput" destination="dynamic-k8s-medium" resources="all"/>
     <!-- OpenMS -->
     <tool id="xcmssplit" destination="dynamic-k8s-large" resources="all"/>
-    <tool id="AdditiveSeries" destination="container-openms"/> 
-    <tool id="BaselineFilter" destination="container-openms"/> 
-    <tool id="CompNovo" destination="container-openms"/> 
-    <tool id="CompNovoCID" destination="container-openms"/> 
-    <tool id="ConsensusID" destination="container-openms"/> 
-    <tool id="ConsensusMapNormalizer" destination="container-openms"/> 
-    <tool id="Decharger" destination="container-openms"/> 
-    <tool id="DTAExtractor" destination="container-openms"/> 
-    <tool id="EICExtractor" destination="container-openms"/> 
-    <tool id="ExternalCalibration" destination="container-openms"/> 
-    <tool id="FalseDiscoveryRate" destination="container-openms"/> 
-    <tool id="FeatureFinderCentroided" destination="container-openms"/> 
-    <tool id="FeatureFinderIdentification" destination="container-openms"/> 
-    <tool id="FeatureFinderIsotopeWavelet" destination="container-openms"/> 
-    <tool id="FeatureFinderMetabo" destination="dynamic-k8s-medium" resources="all"/> 
-    <tool id="FeatureFinderMRM" destination="container-openms"/> 
-    <tool id="FeatureFinderMultiplex" destination="container-openms"/> 
-    <tool id="FeatureLinkerLabeled" destination="dynamic-k8s-medium" resources="all"/> 
-    <tool id="FeatureLinkerUnlabeled" destination="container-openms"/> 
-    <tool id="FeatureLinkerUnlabeledQT" destination="container-openms"/> 
-    <tool id="FidoAdapter" destination="container-openms"/> 
-    <tool id="FileConverter" destination="container-openms"/> 
-    <tool id="FileFilter" destination="container-openms"/> 
-    <tool id="FileInfo" destination="container-openms"/> 
-    <tool id="FileMerger" destination="container-openms"/> 
-    <tool id="HighResPrecursorMassCorrector" destination="container-openms"/> 
-    <tool id="IDConflictResolver" destination="container-openms"/> 
-    <tool id="IDFileConverter" destination="container-openms"/> 
-    <tool id="IDFilter" destination="container-openms"/> 
-    <tool id="IDMapper" destination="container-openms"/> 
-    <tool id="IDMerger" destination="container-openms"/> 
-    <tool id="IDPosteriorErrorProbability" destination="container-openms"/> 
-    <tool id="IDRipper" destination="container-openms"/> 
-    <tool id="IDRTCalibration" destination="container-openms"/> 
-    <tool id="InclusionExclusionListCreator" destination="container-openms"/> 
-    <tool id="InspectAdapter" destination="container-openms"/> 
-    <tool id="InternalCalibration" destination="container-openms"/> 
-    <tool id="IsobaricAnalyzer" destination="container-openms"/> 
-    <tool id="ITRAQAnalyzer" destination="container-openms"/> 
-    <tool id="LuciphorAdapter" destination="container-openms"/> 
-    <tool id="MapAlignerIdentification" destination="container-openms"/> 
-    <tool id="MapAlignerPoseClustering" destination="container-openms"/> 
-    <tool id="MapAlignerSpectrum" destination="container-openms"/> 
-    <tool id="MapNormalizer" destination="container-openms"/> 
-    <tool id="MapRTTransformer" destination="container-openms"/> 
-    <tool id="MapStatistics" destination="container-openms"/> 
-    <tool id="MascotAdapter" destination="container-openms"/> 
-    <tool id="MascotAdapterOnline" destination="container-openms"/> 
-    <tool id="MassTraceExtractor" destination="container-openms"/> 
-    <tool id="MRMMapper" destination="container-openms"/> 
-    <tool id="MSGFPlusAdapter" destination="container-openms"/> 
-    <tool id="MyriMatchAdapter" destination="container-openms"/> 
-    <tool id="MzTabExporter" destination="container-openms"/> 
-    <tool id="NoiseFilterGaussian" destination="container-openms"/> 
-    <tool id="NoiseFilterSGolay" destination="container-openms"/> 
-    <tool id="OMSSAAdapter" destination="container-openms"/> 
-    <tool id="OpenSwathAnalyzer" destination="container-openms"/> 
-    <tool id="OpenSwathAssayGenerator" destination="container-openms"/> 
-    <tool id="OpenSwathChromatogramExtractor" destination="container-openms"/> 
-    <tool id="OpenSwathConfidenceScoring" destination="container-openms"/> 
-    <tool id="OpenSwathDecoyGenerator" destination="container-openms"/> 
-    <tool id="OpenSwathFeatureXMLToTSV" destination="container-openms"/> 
-    <tool id="OpenSwathRTNormalizer" destination="container-openms"/> 
-    <tool id="PeakPickerHiRes" destination="container-openms"/> 
-    <tool id="PeakPickerWavelet" destination="container-openms"/> 
-    <tool id="PepNovoAdapter" destination="container-openms"/> 
-    <tool id="PeptideIndexer" destination="container-openms"/> 
-    <tool id="PhosphoScoring" destination="container-openms"/> 
-    <tool id="PrecursorIonSelector" destination="container-openms"/> 
-    <tool id="PrecursorMassCorrector" destination="container-openms"/> 
-    <tool id="ProteinInference" destination="container-openms"/> 
-    <tool id="ProteinQuantifier" destination="container-openms"/> 
-    <tool id="ProteinResolver" destination="container-openms"/> 
-    <tool id="PTModel" destination="container-openms"/> 
-    <tool id="PTPredict" destination="container-openms"/> 
-    <tool id="RTModel" destination="container-openms"/> 
-    <tool id="RTPredict" destination="container-openms"/> 
-    <tool id="SeedListGenerator" destination="container-openms"/> 
-    <tool id="SpecLibSearcher" destination="container-openms"/> 
-    <tool id="SpectraFilterBernNorm" destination="container-openms"/> 
-    <tool id="SpectraFilterMarkerMower" destination="container-openms"/> 
-    <tool id="SpectraFilterNLargest" destination="container-openms"/> 
-    <tool id="SpectraFilterNormalizer" destination="container-openms"/> 
-    <tool id="SpectraFilterParentPeakMower" destination="container-openms"/> 
-    <tool id="SpectraFilterScaler" destination="container-openms"/> 
-    <tool id="SpectraFilterSqrtMower" destination="container-openms"/> 
-    <tool id="SpectraFilterThresholdMower" destination="container-openms"/> 
-    <tool id="SpectraFilterWindowMower" destination="container-openms"/> 
-    <tool id="SpectraMerger" destination="container-openms"/> 
-    <tool id="TextExporter" destination="container-openms"/> 
-    <tool id="TMTAnalyzer" destination="container-openms"/> 
-    <tool id="TOFCalibration" destination="container-openms"/> 
-    <tool id="XTandemAdapter" destination="container-openms"/> 
+    <tool id="AdditiveSeries" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="BaselineFilter" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="CompNovo" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="CompNovoCID" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="ConsensusID" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="ConsensusMapNormalizer" destination="dynamic-k8s-xlarge" resources="all"/> 
+    <tool id="Decharger" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="DTAExtractor" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="EICExtractor" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="ExternalCalibration" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="FalseDiscoveryRate" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="FeatureFinderCentroided" destination="dynamic-k8s-xlarge" resources="all"/> 
+    <tool id="FeatureFinderIdentification" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="FeatureFinderIsotopeWavelet" destination="dynamic-k8s-xlarge" resources="all"/> 
+    <tool id="FeatureFinderMetabo" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="FeatureFinderMRM" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="FeatureFinderMultiplex" destination="dynamic-k8s-xlarge" resources="all"/> 
+    <tool id="FeatureLinkerLabeled" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="FeatureLinkerUnlabeled" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="FeatureLinkerUnlabeledQT" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="FidoAdapter" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="FileConverter" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="FileFilter" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="FileInfo" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="FileMerger" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="HighResPrecursorMassCorrector" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="IDConflictResolver" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="IDFileConverter" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="IDFilter" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="IDMapper" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="IDMerger" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="IDPosteriorErrorProbability" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="IDRipper" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="IDRTCalibration" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="InclusionExclusionListCreator" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="InspectAdapter" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="InternalCalibration" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="IsobaricAnalyzer" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="ITRAQAnalyzer" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="LuciphorAdapter" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="MapAlignerIdentification" destination="dynamic-k8s-xlarge" resources="all"/> 
+    <tool id="MapAlignerPoseClustering" destination="dynamic-k8s-xlarge" resources="all"/> 
+    <tool id="MapAlignerSpectrum" destination="dynamic-k8s-xlarge" resources="all"/> 
+    <tool id="MapNormalizer" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="MapRTTransformer" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="MapStatistics" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="MascotAdapter" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="MascotAdapterOnline" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="MassTraceExtractor" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="MRMMapper" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="MSGFPlusAdapter" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="MyriMatchAdapter" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="MzTabExporter" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="NoiseFilterGaussian" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="NoiseFilterSGolay" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="OMSSAAdapter" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="OpenSwathAnalyzer" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="OpenSwathAssayGenerator" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="OpenSwathChromatogramExtractor" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="OpenSwathConfidenceScoring" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="OpenSwathDecoyGenerator" destination="dynamic-k8s-large" resources="all"/> 
+    <tool id="OpenSwathFeatureXMLToTSV" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="OpenSwathRTNormalizer" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="PeakPickerHiRes" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="PeakPickerWavelet" destination="dynamic-k8s-xlarge" resources="all"/> 
+    <tool id="PepNovoAdapter" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="PeptideIndexer" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="PhosphoScoring" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="PrecursorIonSelector" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="PrecursorMassCorrector" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="ProteinInference" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="ProteinQuantifier" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="ProteinResolver" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="PTModel" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="PTPredict" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="RTModel" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="RTPredict" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SeedListGenerator" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="SpecLibSearcher" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SpectraFilterBernNorm" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SpectraFilterMarkerMower" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SpectraFilterNLargest" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SpectraFilterNormalizer" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SpectraFilterParentPeakMower" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SpectraFilterScaler" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SpectraFilterSqrtMower" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SpectraFilterThresholdMower" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SpectraFilterWindowMower" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="SpectraMerger" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="TextExporter" destination="dynamic-k8s-small" resources="all"/> 
+    <tool id="TMTAnalyzer" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="TOFCalibration" destination="dynamic-k8s-medium" resources="all"/> 
+    <tool id="XTandemAdapter" destination="dynamic-k8s-medium" resources="all"/> 
     <!-- MetFrag -->
     <tool id="metfrag-cli-batch" destination="dynamic-k8s-large" resources="all"/>
     <tool id="msnbase-read-msms" destination="dynamic-k8s-medium" resources="all"/>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -100,7 +100,8 @@
     </destination>
     <destination id="papy-container" runner="k8s">
       <param id="docker_enabled">true</param>
-    </destination>      
+    </destination>     
+    <!-- 
     <destination id="msconvert2-container" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
@@ -109,6 +110,7 @@
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>
+   -->
     <destination id="nmrmlconv-container" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
@@ -117,6 +119,7 @@
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>
+    <!-- 
     <destination id="nmrglue-container" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
@@ -125,6 +128,7 @@
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>
+   -->
     <destination id="soap-nmr-container" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
@@ -300,7 +304,7 @@
     <tool id="generic_filter" destination="dynamic-k8s-small" resources="all"/>
     <tool id="Batch_correction" destination="dynamic-k8s-small" resources="all"/>
     <tool id="normalization" destination="dynamic-k8s-small" resources="all"/>
-    <tool id="msconvert2" destination="msconvert2-container"/>
+    <!-- <tool id="msconvert2" destination="msconvert2-container"/> -->
     <!-- new NMR -->
     <tool id="metabolab" destination="dynamic-k8s-large" resources="all"/>
     <tool id="mtbls_nmr_raw_dummy_importer" destination="nmrmlconv-container"/>
@@ -310,7 +314,7 @@
     <tool id="rnmr1d-stacked-plot" destination="dynamic-k8s-tiny" resources="all"/>
     <tool id="rnmr1d-prepare-output" destination="dynamic-k8s-small" resources="all"/>
     <!-- old NMR -->
-    <tool id="mtbls2nmrglue" destination="nmrglue-container"/>
+    <!-- <tool id="mtbls2nmrglue" destination="nmrglue-container"/> -->
     <tool id="soap_process" destination="soap-nmr-container"/>
     <tool id="soap_opls" destination="soap-nmr-container"/>
     <!-- other NMR -->

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -117,14 +117,6 @@
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>
-    <destination id="rnmr1d-container" runner="k8s">
-      <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
-      <param id="docker_owner_override">phnmnl</param>
-      <param id="docker_image_override">rnmr1d</param>
-      <param id="docker_tag_override">latest</param>
-      <param id="max_pod_retrials">3</param>
-      <param id="docker_enabled">true</param>
-    </destination>
     <destination id="nmrglue-container" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
@@ -345,7 +337,7 @@
     <tool id="zip-nmrml-collection" destination="dynamic-k8s-small" resources="all"/>
     <tool id="rnmr1d" destination="dynamic-k8s-xlarge" resources="all"/>
     <tool id="rnmr1d-stacked-plot" destination="dynamic-k8s-tiny" resources="all"/>
-    <tool id="rnmr1d-prepare-output" destination="rnmr1d-container"/>
+    <tool id="rnmr1d-prepare-output" destination="dynamic-k8s-small" resources="all"/>
     <!-- old NMR -->
     <tool id="mtbls2nmrglue" destination="nmrglue-container"/>
     <tool id="soap_process" destination="soap-nmr-container"/>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -237,14 +237,6 @@
       <param id="max_pod_retrials">1</param>
       <param id="docker_enabled">true</param>
     </destination>
-    <destination id="container-passatutto" runner="k8s">
-      <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
-      <param id="docker_owner_override">phnmnl</param>
-      <param id="docker_image_override">passatutto</param>
-      <param id="docker_tag_override">latest</param>
-      <param id="max_pod_retrials">1</param>
-      <param id="docker_enabled">true</param>
-    </destination>
     <destination id="container-isatab2json" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -189,14 +189,6 @@
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>
-    <destination id="metfrag-cli-batch-container" runner="k8s">
-      <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
-      <param id="docker_owner_override">phnmnl</param>
-      <param id="docker_image_override">metfrag-cli-batch</param>
-      <param id="docker_tag_override">latest</param>
-      <param id="max_pod_retrials">3</param>
-      <param id="docker_enabled">true</param>
-    </destination>
     <destination id="container-mtblisa" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -292,11 +292,6 @@
          a tag, a handler or destination that matches that tag will be
          chosen at random.  -->
     <tool id="pathway_enrichment" destination="dynamic-k8s-large" resources="all"/>
-
-    <!-- Uppsala demo tools
-    <tool id="BatchFeatureRemoval" destination="batchfeature-container"/>
-    <tool id="upps_blankfilter" destination="blankfilter-container"/>
-    <tool id="log2transformation" destination="log2transformation-container"/> -->
     
     <!-- Fluxomics -->
     <tool id="iso2flux" destination="dynamic-k8s-small" resources="all"/>     

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -237,14 +237,6 @@
       <param id="max_pod_retrials">1</param>
       <param id="docker_enabled">true</param>
     </destination>
-    <destination id="msnbase-container" runner="k8s">
-      <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
-      <param id="docker_owner_override">phnmnl</param>
-      <param id="docker_image_override">msnbase</param>
-      <param id="docker_tag_override">latest</param>
-      <param id="max_pod_retrials">1</param>
-      <param id="docker_enabled">true</param>
-    </destination>
     <destination id="container-passatutto" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -315,7 +315,7 @@
     <tool id="escher-fluxomics" destination="dynamic-k8s-tiny" resources="all"/>
     <!-- ICL -->
     <tool id="batman-nmr" destination="batman-container"/>
-    <tool id="nmrml2batman" destination="dynamic-k8s-small"/>
+    <tool id="nmrml2batman" destination="dynamic-k8s-small" resources="all"/>
     <tool id="power-analysis" destination="papy-container"/>
     <!-- W4M Sacurine -->
     <tool id="mtbls-dwnld" destination="dynamic-k8s-tiny" resources="all"/>
@@ -357,8 +357,8 @@
     <tool id="xcms-group-peaks" destination="dynamic-k8s-large" resources="all"/>
     <tool id="xcms-correct-rt" destination="dynamic-k8s-large" resources="all"/>
     <tool id="xcms-fill-peaks" destination="dynamic-k8s-large" resources="all"/>
-    <tool id="xcms-dilutionfilter" destination="dynamic-k8s-medium" />
-    <tool id="xcms-blankfilter" destination="dynamic-k8s-medium" />
+    <tool id="xcms-dilutionfilter" destination="dynamic-k8s-medium" resources="all"/>
+    <tool id="xcms-blankfilter" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="save_chromatogram" destination="dynamic-k8s-small" resources="all" />
     <tool id="show_chromatogram" destination="dynamic-k8s-small" resources="all" />
     <!-- CAMERA -->
@@ -373,9 +373,9 @@
     <tool id="camera-find-isotopes" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="camera-find-adducts" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="unzip-collection" destination="camera-container"/>
-    <tool id="camera-prepareoutput" destination="dynamic-k8s-medium" />
+    <tool id="camera-prepareoutput" destination="dynamic-k8s-medium" resources="all"/>
     <!-- OpenMS -->
-    <tool id="xcmssplit" destination="dynamic-k8s-large" />
+    <tool id="xcmssplit" destination="dynamic-k8s-large" resources="all"/>
     <tool id="AdditiveSeries" destination="container-openms"/> 
     <tool id="BaselineFilter" destination="container-openms"/> 
     <tool id="CompNovo" destination="container-openms"/> 
@@ -475,11 +475,11 @@
     <tool id="map-msms2camera" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="msms2metfrag" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="metfrag-vis" destination="dynamic-k8s-small" resources="all"/>
-    <tool id="metfrag-cli-batch-multiple" destination="dynamic-k8s-large" />
-    <tool id="msnbase-filter-merge-msms" destination="dynamic-k8s-medium" />
-    <tool id="msms2metfrag-multiple" destination="dynamic-k8s-medium" />
-    <tool id="aggregatemetfrag" destination="dynamic-k8s-medium" />
-    <tool id="passatutto" destination="dynamic-k8s-medium" />
+    <tool id="metfrag-cli-batch-multiple" destination="dynamic-k8s-large" resources="all"/>
+    <tool id="msnbase-filter-merge-msms" destination="dynamic-k8s-medium" resources="all"/>
+    <tool id="msms2metfrag-multiple" destination="dynamic-k8s-medium" resources="all"/>
+    <tool id="aggregatemetfrag" destination="dynamic-k8s-medium" resources="all"/>
+    <tool id="passatutto" destination="dynamic-k8s-medium" resources="all"/>
     <!-- ISA related tools -->
     <tool id="isa_create_metabo" destination="container-isatab-create" resources="all"/>
     <tool id="isa_get_data_files" destination="dynamic-k8s-tiny" resources="all"/>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -74,14 +74,6 @@
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>
-    <destination id="camera-container" runner="k8s">
-      <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
-      <param id="docker_owner_override">phnmnl</param>
-      <param id="docker_image_override">camera</param>
-      <param id="docker_tag_override">v1.33.3_cv0.10.59</param>
-      <param id="max_pod_retrials">1</param>
-      <param id="docker_enabled">true</param>
-    </destination>
     <destination id="isodyn-container" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
@@ -337,17 +329,17 @@
     <tool id="save_chromatogram" destination="dynamic-k8s-small" resources="all" />
     <tool id="show_chromatogram" destination="dynamic-k8s-small" resources="all" />
     <!-- CAMERA -->
-    <tool id="consensusXMLToXcms" destination="camera-container" />
-    <tool id="cameraToFeatureXML" destination="camera-container" />
-    <tool id="featureXMLToCAMERA" destination="camera-container" />
-    <tool id="featureXMLToXcms" destination="camera-container" />
-    <tool id="zip-collection" destination="camera-container"/>
+    <tool id="consensusXMLToXcms" destination="dynamic-k8s-medium" resources="all"/>
+    <tool id="cameraToFeatureXML" destination="dynamic-k8s-medium" resources="all"/>
+    <tool id="featureXMLToCAMERA" destination="dynamic-k8s-medium" resources="all"/>
+    <tool id="featureXMLToXcms" destination="dynamic-k8s-medium" resources="all"/>
+    <tool id="zip-collection" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="camera-annotate-peaks" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="camera-group-fwhm" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="camera-group-corr" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="camera-find-isotopes" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="camera-find-adducts" destination="dynamic-k8s-medium" resources="all"/>
-    <tool id="unzip-collection" destination="camera-container"/>
+    <tool id="unzip-collection" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="camera-prepareoutput" destination="dynamic-k8s-medium" resources="all"/>
     <!-- OpenMS -->
     <tool id="xcmssplit" destination="dynamic-k8s-large" resources="all"/>

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -446,6 +446,7 @@ assignment:
   - featureXMLToCAMERA
   - featureXMLToXcms
   - zip-collection
+  - unzip-collection
   - camera-annotate-peaks
   - camera-group-fwhm
   - camera-group-corr

--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -124,7 +124,7 @@
       <tool file="phenomenal/nmr/batman.xml"/>
       <tool file="phenomenal/nmr/nmrml2batman.xml"/>
       <tool file="phenomenal/nmr/metabomatching.xml"/>
-      <tool file="phenomenal/nmr/mtbls2nmrglue.xml"/>
+      <!-- <tool file="phenomenal/nmr/mtbls2nmrglue.xml"/> -->
       <tool file="phenomenal/nmr/soap_process.xml"/>
       <tool file="phenomenal/nmr/soap_opls.xml"/>
    </section>


### PR DESCRIPTION
This PR aims to tidy up some job_conf and tool_conf to get rid of tools that were delayed for the release and to make sure that tools included are all on release tags.

Please @korseby and @c-ruttkies take a look, to see if we need to revert any of this.