### PR TITLE
Fix error_trap function

### DIFF
--- a/ansible/run_galaxy_config.sh
+++ b/ansible/run_galaxy_config.sh
@@ -13,7 +13,7 @@ function log() {
 }
 
 function error_trap() {
-  log "**** Error at line ${BASH_LINENO[0]} running command ${BASH_COMMAND} ****"
+  log "#### Error at line ${BASH_LINENO[0]} running command ${BASH_COMMAND} ####"
 }
 
 trap error_trap ERR


### PR DESCRIPTION
Due to the quoting, the asterisks in the string were getting expanded,
writing the file listing of the CWD to the log