### PR TITLE
ISA create tool hotfix

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -197,7 +197,7 @@
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
       <param id="docker_image_override">isatab-create</param>
-      <param id="docker_tag_override">v0.9.5_cv0.3.11.55</param>
+      <param id="docker_tag_override">v0.9.5_cv0.3.10.55</param>
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -197,7 +197,7 @@
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
       <param id="docker_image_override">isatab-create</param>
-      <param id="docker_tag_override">v0.9.5_cv0.3.10.55</param>
+      <param id="docker_tag_override">v0.9.5_cv0.3.14.60</param>
       <param id="max_pod_retrials">3</param>
       <param id="docker_enabled">true</param>
     </destination>

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -483,7 +483,7 @@ assignment:
 - docker_image_override: isatab-create
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu
-  docker_tag_override: v0.9.5_cv0.3.10.55
+  docker_tag_override: v0.9.5_cv0.3.14.60
   max_pod_retrials: 3
   tools_id:
   - isatab-create

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -483,7 +483,7 @@ assignment:
 - docker_image_override: isatab-create
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu
-  docker_tag_override: v0.9.5_cv0.3.11.55
+  docker_tag_override: v0.9.5_cv0.3.10.55
   max_pod_retrials: 3
   tools_id:
   - isatab-create

--- a/tools/phenomenal/isatools/create_metabo/isa_create_metabo.xml
+++ b/tools/phenomenal/isatools/create_metabo/isa_create_metabo.xml
@@ -1,4 +1,4 @@
-<tool id="isa_create_metabo" name="Create ISA in Galaxy" version="1.2.0">
+<tool id="isa_create_metabo" name="Create ISA in Galaxy" version="1.1.0">
     <description>Interactive tool to create ISA archives based on study design information</description>
 
     <macros>
@@ -13,6 +13,7 @@
     <stdio>
         <exit_code range="1:" />
     </stdio>
+
     <command>
         <![CDATA[
 


### PR DESCRIPTION
Fixes upstream in `isa-api` and `isatools-galaxy`, have rebuild the `container-isatab-create` so this fix updates the container tag and minor change in tool XML.