### PR TITLE
[Galaxy-stable] Moves ephemeris inst. (workflow sharing) to init

### DIFF
--- a/Dockerfile_init
+++ b/Dockerfile_init
@@ -7,6 +7,17 @@ LABEL software="Galaxy Init"
 LABEL software.version="17.05-pheno-lr"
 LABEL version="1.3"
 
+RUN wget -O ephemeris.tar https://api.github.com/repos/galaxyproject/ephemeris/tarball/eeee87a57379b8b639b06c2a50038ef449c28d73 && \
+    tar -xf ephemeris.tar && rm ephemeris.tar && \
+    virtualenv venv-workflow && \
+    /bin/bash -c "source venv-workflow/bin/activate && \
+                  pip install 'pip>=8.1' && \
+                  pip install ./galaxyproject-ephemeris-eeee87a \
+                      --index-url https://pypi.python.org/simple && \
+                  pip install urllib3[secure] && \
+                  deactivate && \
+                  virtualenv --relocatable venv-workflow"
+
 #COPY config/galaxy.ini config/galaxy.ini
 COPY config/job_conf.xml config/job_conf.xml
 COPY config/tool_conf.xml config/tool_conf.xml

--- a/post-start-actions.sh
+++ b/post-start-actions.sh
@@ -5,13 +5,7 @@ echo "Adding workflows to Galaxy for user $GALAXY_DEFAULT_ADMIN_USER from dir $W
 
 # Waits for the instance to be up and adds the workflows in a non-blocking fashion, so that tail below proceeds
 # uses ephemeris. Virtualenv needed while pre 0.8 versions of ephemeris are being used in other places
-virtualenv .ephemeris-publishable-workflow && \
-  source .ephemeris-publishable-workflow/bin/activate && \
-  apt-get update && apt-get install -y --no-install-recommends git && \
-  pip install -U pip && pip install -e git://github.com/galaxyproject/ephemeris.git@#egg=ephemeris && \
-  echo "...dependencies for workflows installed"
-  workflow-install -g http://127.0.0.1 -v -a $GALAXY_DEFAULT_ADMIN_KEY \
+source /export/venv-workflow/bin/activate && \
+  /export/venv-workflow/bin/workflow-install -g http://127.0.0.1 -v -a $GALAXY_DEFAULT_ADMIN_KEY \
       -w /export/workflows_to_load --publish_workflows && \
-  deactivate && \
-  apt-get purge -y git && \
-rm -rf .ephemeris-publishable-workflow
+  deactivate \


### PR DESCRIPTION
This PR reduces the setup time of workflows by moving the ephemeris from runtime to the galaxy-init-pheno-flavoured container. It also simplifies this installation. 