### PR TITLE
Fixes biosigner issue with dynamic destination 

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -226,7 +226,7 @@
     <tool id="isa2w4m" destination="dynamic-k8s-tiny" resources="all"/>
     <tool id="Univariate" destination="dynamic-k8s-small" resources="all"/>
     <tool id="Multivariate" destination="dynamic-k8s-small" resources="all"/>
-    <tool id="Biosigner" destination="biosigner-container" resources="all"/>
+    <tool id="biosigner" destination="dynamic-k8s-large" resources="all"/>
     <tool id="lcmsmatching" destination="dynamic-k8s-small" resources="all"/>
     <tool id="Transformation" destination="dynamic-k8s-small" resources="all"/>
     <tool id="quality_metrics" destination="dynamic-k8s-small" resources="all"/>

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -91,7 +91,6 @@ assignment:
   max_pod_retrials: 3
   tools_id:
   - Transformation
-
 - docker_image_override: batch_correction
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu
@@ -99,7 +98,6 @@ assignment:
   max_pod_retrials: 3
   tools_id:
   - Batch_correction
-
 - docker_image_override: tool-generic_filter
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu
@@ -107,7 +105,6 @@ assignment:
   max_pod_retrials: 3
   tools_id:
   - generic_filter
-
 - docker_image_override: qualitymetrics
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu
@@ -115,14 +112,13 @@ assignment:
   max_pod_retrials: 3
   tools_id:
   - quality_metrics
-
 - docker_image_override: biosigner
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu
   docker_tag_override: v2.2.7_cv1.3.15
   max_pod_retrials: 3
   tools_id:
-  - Biosigner
+  - biosigner
 - docker_image_override: openms
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu


### PR DESCRIPTION
Biosigner was having issues when used with dynamic destinations due to lower/uppercase different usage of its tool id in a few places. This PR fixes that, also described at #165.

Joint work with @pkrog. 