### PR TITLE
Feature/add ipo - Integration of IPO to the Phenomenal Galaxy interface

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -57,7 +57,15 @@
       <param id="type">python</param>
       <param id="function">k8s_wrapper_xlarge</param>
     </destination>
-    
+   
+    <destination id="ipo-container" runner="k8s">
+      <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
+      <param id="docker_owner_override">phnmnl</param>
+      <param id="docker_image_override">ipo</param>
+      <param id="docker_tag_override">latest</param>
+      <param id="max_pod_retrials">3</param>
+      <param id="docker_enabled">true</param>
+    </destination>
     <destination id="biosigner-container" runner="k8s">
       <param id="docker_repo_override">container-registry.phenomenal-h2020.eu</param>
       <param id="docker_owner_override">phnmnl</param>
@@ -255,6 +263,9 @@
     <tool id="Metabolite_ID_Converter" destination="container-metaboliteidconverter" />
     <tool id="metabomatching" destination="dynamic-k8s-small" resources="all"/>
     <tool id="ms-vfetc" destination="leidenuniv-ms-vfetc-container"/>
+    <!-- new IPO -->
+    <tool id="ipo4xcmsSet" destination="dynamic-k8s-medium" resources="all"/>
+    <tool id="ipo4retgroup" destination="dynamic-k8s-medium" resources="all"/>
     <!-- new XCMS -->
     <tool id="xcms-find-peaks" destination="dynamic-k8s-large" resources="all"/>
     <tool id="xcms-collect-peaks" destination="dynamic-k8s-medium" resources="all"/>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -264,8 +264,8 @@
     <tool id="metabomatching" destination="dynamic-k8s-small" resources="all"/>
     <tool id="ms-vfetc" destination="leidenuniv-ms-vfetc-container"/>
     <!-- new IPO -->
-    <tool id="ipo4xcmsSet" destination="dynamic-k8s-medium" resources="all"/>
-    <tool id="ipo4retgroup" destination="dynamic-k8s-medium" resources="all"/>
+    <tool id="ipo4xcmsSet" destination="dynamic-k8s-xlarge" resources="all"/>
+    <tool id="ipo4retgroup" destination="dynamic-k8s-xlarge" resources="all"/>
     <!-- new XCMS -->
     <tool id="xcms-find-peaks" destination="dynamic-k8s-large" resources="all"/>
     <tool id="xcms-collect-peaks" destination="dynamic-k8s-medium" resources="all"/>

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -497,3 +497,11 @@ assignment:
   - dimspy_hdf5_to_txt
   - dimspy_merge_peaklists
   - dimspy_get_peaklists
+- docker_image_override: ipo
+  docker_owner_override: phnmnl
+  docker_repo_override: container-registry.phenomenal-h2020.eu
+  docker_tag_override: latest
+  max_pod_retrials: 3
+  tools_id:
+  - ipo4xcmsSet
+  - ipo4retgroup

--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -133,6 +133,8 @@
     <!-- 
     <tool file="phenomenal/ms/msconvert2.xml"/>
     -->
+    <tool file="phenomenal/ms/ipo/ipo4xcmsSet.xml" labels="IPO"/>
+    <tool file="phenomenal/ms/ipo/ipo4retgroup.xml" labels="IPO"/>
     <tool file="phenomenal/ms/xcms/xcms-find-peaks.xml" labels="XCMS"/>
     <tool file="phenomenal/ms/xcms/xcms-split-peaks.xml" labels="XCMS"/>
     <tool file="phenomenal/ms/xcms/xcms-collect-peaks.xml" labels="XCMS"/>

--- a/tools/phenomenal/ms/ipo/ipo4retgroup.xml
+++ b/tools/phenomenal/ms/ipo/ipo4retgroup.xml
@@ -22,10 +22,10 @@
 
         image '$image'
         
-        #if $input.is_of_type("mzxml") or $input.is_of_type("mzml") or $input.is_of_type("mzdata") or $input.is_of_type("netcdf"):
-            singlefile_galaxyPath '$input' singlefile_sampleName '$input.name'
+        #if $ipo4retgroup_input.is_of_type("mzxml") or $ipo4retgroup_input.is_of_type("mzml") or $ipo4retgroup_input.is_of_type("mzdata") or $ipo4retgroup_input.is_of_type("netcdf"):
+            singlefile_galaxyPath '$ipo4retgroup_input' singlefile_sampleName '$ipo4retgroup_input.name'
         #else
-            zipfile '$input'
+            zipfile '$ipo4retgroup_input'
         #end if
 
         parametersOutput '$parametersOutput'
@@ -70,7 +70,7 @@
 
     <inputs>
     
-        <param name="input" type="data" format="mzxml,mzml,mzdata,netcdf,no_unzip.zip,zip" label="File(s) from your history containing your chromatograms" help="Single file mode for the format: mzxml, mzml, mzdata and netcdf. Zip file mode for the format: no_unzip.zip, zip. See the help section below." />
+        <param name="ipo4retgroup_input" type="data" format="mzxml,mzml,mzdata,netcdf,no_unzip.zip,zip" label="File(s) from your history containing your chromatograms" help="Single file mode for the format: mzxml, mzml, mzdata and netcdf. Zip file mode for the format: no_unzip.zip, zip. See the help section below." />
 
         <param name="image" type="data" format="rdata.xcms.raw,rdata.xcms.group,rdata.xcms.retcor,rdata" label="xset RData file" help="output file from another function xcms (xcmsSet, retcor etc.)" />
 
@@ -394,4 +394,3 @@ Changelog/News
 
     <expand macro="citation" />
 </tool>
-

--- a/tools/phenomenal/ms/ipo/ipo4retgroup.xml
+++ b/tools/phenomenal/ms/ipo/ipo4retgroup.xml
@@ -1,6 +1,6 @@
 <tool id="ipo4retgroup" name="IPO for group and retcor" version="0.0.1">
 
-    <description>IPO optimization process for xcms.group and xcms.retcor</description>
+    <description>IPO optimization process for retention time correction and peak grouping</description>
 
     <macros>
         <import>macros.xml</import>
@@ -233,56 +233,66 @@
 
 @HELP_AUTHORS@
 
-===============
-IPO.ipo4xcmsSet
-===============
+================
+IPO.ipo4retgroup
+================
 
 -----------
 Description
 -----------
 
-A Tool for automated Optimization of XCMS Parameters
+**IPO for retgroup**  This tool optimizes retention time correction and grouping parameters
 
 
 -----------------
 Workflow position
 -----------------
 
+|
+
 **Upstream tools**
 
-========================= ================= ======= =========
-Name                      output file       format  parameter
-========================= ================= ======= =========
-NA                        NA                zip     NA
-========================= ================= ======= =========
++---------------------------+--------------------------------+-----------------+
+| Name                      | Output file                    | Format          |
++===========================+================================+=================+
+|                           | IPO_parameters4retcorGroup.tsv | Tabular         |
+|                           +--------------------------------+-----------------+
+|       ipo4retgroup        | resultPeakpicking.RData        | RData           |
+|                           +--------------------------------+-----------------+
+|                           | best_xcmsSet.RData             | RData           |
+|                           +--------------------------------+-----------------+
+|                           | run_instrument_infos.tsv       | Tabular         |
++---------------------------+--------------------------------+-----------------+
 
+|
 
 **Downstream tools**
 
-+---------------------------+----------------------+-----------------+
-| Name                      | Output file          | Format          |
-+===========================+======================+=================+
-|xcms.xcmsSet               | parametersOutput.tsv | Tabular         |
-+---------------------------+--------------------+-------------------+
-
++---------------------------+---------------------------------+-----------------+
+| Name                      | Output file                     | Format          |
++===========================+=================================+=================+
+| xcms-group-peak           | xcms_group_peaks_output_1.rdata | RData           |
++---------------------------+---------------------------------+-----------------+
+| xcms-correct-rt           | xcms_correct_rt_output_1.rdata  | RData           |
++---------------------------+---------------------------------+-----------------+
 
 
 -----------
 Input files
 -----------
 
-+---------------------------+------------+
-| Parameter : num + label   |   Format   |
-+===========================+============+
-| 1 : Choose your inputs    |   zip      |
-+---------------------------+------------+
+1. Input samples to analyse (mzData, mzML, mzXML, netCDF, zip). If you just ran the previous tool "ipo for xcmsSet" it refers to the same input you used for this tool.
+2. The best xcmsSet R object (RData) with optimized parameters. The file to use from the previous tool is: best_xcmsSet.RData
+
+|
 
 **Choose your inputs**
 
-You have two methods for your inputs:
+You have three methods for your inputs:
 
     | Zip file (recommended): You can put a zip file containing your inputs: myinputs.zip (containing all your conditions as sub-directories).
     | library folder: You must specify the name of your "library" (folder) created within your space project (for example: /projet/externe/institut/login/galaxylibrary/yourlibrary). Your library must contain all your conditions as sub-directories.
+    | MZ file: You can give only one mz file (mzData, mzML, mzXML, netCDF) as input.
 
 Steps for creating the zip file
 -------------------------------
@@ -329,13 +339,18 @@ m/z Encoding: **64**
 
 Intensity Encoding: **64**
 
+|
 
 ----------
 Parameters
 ----------
 
+|
+
 Extraction method for peaks detection
 -------------------------------------
+
+|
 
 **Matched Filter**
 
@@ -343,20 +358,28 @@ Extraction method for peaks detection
     | For a discussion of how model peak width affects the signal to noise ratio, see Danielsson et al. (2002).
 
 
-**cent Wave**
+**Cent Wave**
 
     | This algorithm is most suitable for high resolution LC/{TOF,OrbiTrap,FTICR}-MS data in centroid mode.
     | Due to the fact that peak centroids are used, a binning step is not necessary.
     | The method is capable of detecting close-by-peaks and also overlapping peaks. Some efforts are made to detect the exact peak boundaries to get precise peak integrals.
 
+|
 
 ------------
 Output files
 ------------
 
+|
+
 IPO_parameters4retcorGroup.tsv
 
-    | Optimal parameters for xcmsSet
+    | Optimal parameters for retention time correction and peak grouping
+
+
+.. class:: infomark
+
+You can continue your analysis with xcms-group-peak and xcms-correct-rt using the optimized parameters.
 
 
 
@@ -371,3 +394,4 @@ Changelog/News
 
     <expand macro="citation" />
 </tool>
+

--- a/tools/phenomenal/ms/ipo/ipo4retgroup.xml
+++ b/tools/phenomenal/ms/ipo/ipo4retgroup.xml
@@ -1,0 +1,373 @@
+<tool id="ipo4retgroup" name="IPO for group and retcor" version="0.0.1">
+
+    <description>IPO optimization process for xcms.group and xcms.retcor</description>
+
+    <macros>
+        <import>macros.xml</import>
+
+        <macro name="group_density_bw_fixed">
+            <param name="bw" type="integer" value="30" label="Bandwidth" help="[bw] bandwidth (standard deviation or half width at half maximum) of gaussian smoothing kernel to apply to the peak density chromatogram" />
+        </macro>
+
+        <macro name="group_density_mzwid_fixed">
+            <param name="mzwid" type="float" value="0.25" label="Width of overlapping m/z slices" help="[mzwid] to use for creating peak density chromatograms and grouping peaks across samples " />
+        </macro>
+    </macros>
+
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+
+    <command><![CDATA[
+        LANG=C ipo4retgroup.r
+
+        image '$image'
+        
+        #if $input.is_of_type("mzxml") or $input.is_of_type("mzml") or $input.is_of_type("mzdata") or $input.is_of_type("netcdf"):
+            singlefile_galaxyPath '$input' singlefile_sampleName '$input.name'
+        #else
+            zipfile '$input'
+        #end if
+
+        parametersOutput '$parametersOutput'
+        
+        samplebyclass $samplebyclass
+
+        @COMMAND_NSLAVES@
+
+        ## group methods
+
+        sleep 0.001
+        #if $group.methods.method == "density":
+            bw "c($group.methods.section_group_density_optiomizable.conditional_parameter.bw)"
+            mzwid "c($group.methods.section_group_density_optiomizable.conditional_parameter.mzwid)"
+
+            minfrac $group.methods.section_group_density_non_optimizable.minfrac
+            max $group.methods.section_group_density_non_optimizable.max
+        #end if
+
+        ## retcor methods
+
+        #if $retcor.methods.retcormethod == "obiwarp":
+            retcorMethod obiwarp
+            profStep $retcor.methods.section_retcor_obiwarp_non_optimizable.profStep
+
+        #elif $retcor.methods.retcormethod == "peakgroups":
+            retcorMethod loess
+            smooth $retcor.methods.section_retcor_peakgroups_non_optimizable.smooth
+            extra $retcor.methods.section_retcor_peakgroups_non_optimizable.extra
+            missing $retcor.methods.section_retcor_peakgroups_non_optimizable.missing
+            span $retcor.methods.section_retcor_peakgroups_non_optimizable.span
+            family $retcor.methods.section_retcor_peakgroups_non_optimizable.family
+            plottype $retcor.methods.section_retcor_peakgroups_non_optimizable.plottype
+        #elif $retcor.methods.retcormethod == "none":
+            retcorMethod none
+        #end if
+
+        @COMMAND_FILE_LOAD@
+
+        @COMMAND_LOG_EXIT@
+    ]]></command>
+
+    <inputs>
+    
+        <param name="input" type="data" format="mzxml,mzml,mzdata,netcdf,no_unzip.zip,zip" label="File(s) from your history containing your chromatograms" help="Single file mode for the format: mzxml, mzml, mzdata and netcdf. Zip file mode for the format: no_unzip.zip, zip. See the help section below." />
+
+        <param name="image" type="data" format="rdata.xcms.raw,rdata.xcms.group,rdata.xcms.retcor,rdata" label="xset RData file" help="output file from another function xcms (xcmsSet, retcor etc.)" />
+
+        <param name="samplebyclass" type="integer" value="2" label="Number of samples used per class to estimate the best parameters" help="Set to 0 to use the whole dataset. To save time, reduce this number" />
+
+        <section name="group" title="Group Options" expanded="True">
+            <conditional name="methods">
+                <param name="method" type="select" label="Method to use for grouping" help="[method] See the help section below. Only the density method is available so far">
+                    <option value="density" selected="true">density</option>
+                </param>
+                <when value="density">
+                    <section name="section_group_density_optiomizable"  title="Optimizable parameters" expanded="True">
+                        <conditional name="conditional_parameter">
+                            <param name="select_parameter" type="select" label="Which parameter do you want to optimize?" help="Only one paramter can be optimized at once. The other will require fixed values">
+                                <option value="bw">Bandwidth [bw]</option>
+                                <option value="mzwid">Width of overlapping m/z slices [mzwid]</option>
+                            </param>
+                            <when value="bw">
+                                <param name="bw" type="text" value="22,38" label="Range for Bandwidth" help="[bw] bandwidth (standard deviation or half width at half maximum) of gaussian smoothing kernel to apply to the peak density chromatogram (ex: 22,38)">
+                                    <validator type="regex" message="Should be this format XX,YY">[0-9]+,[0-9]+</validator>
+                                </param>
+                                <expand macro="group_density_mzwid_fixed" />
+                            </when>
+                            <when value="mzwid">
+                                <param name="mzwid" type="text" value="0.015,0.035" label="Range for Width of overlapping m/z slices" help="[mzwid] to use for creating peak density chromatograms and grouping peaks across samples (ex: 0.015,0.035)" >
+                                    <validator type="regex" message="Should be one combinaison of those format: XX,YY or -XX,YY or XX.XX,YY.YY">[\-]?[0-9]+[\.]?[0-9]*,[\-]?[0-9]+[\.]?[0-9]*</validator>
+                                </param>
+                                <expand macro="group_density_bw_fixed" />
+                            </when>
+                        </conditional>
+                    </section>
+                    <section name="section_group_density_non_optimizable" title="Non optimizable parameters"  expanded="True">
+                        <param name="minfrac" type="float" value="0.5" label="Minimum fraction of samples necessary" help="[minfrac] in at least one of the sample groups for it to be a valid group" />
+                        <param name="max" type="integer" value="50" label="Maximum number of groups to identify in a single m/z slice" help="[max]" />
+                    </section>
+                </when>
+            </conditional>
+        </section>
+
+        <section name="retcor" title="Retcor Options" expanded="True">
+            <conditional name="methods">
+                <param name="retcormethod" type="select" label="Method to use for retention time correction" help="[method] See the help section below" >
+                    <option value="obiwarp" selected="true">obiwarp</option>
+                    <option value="peakgroups">peakgroups</option>
+                </param>
+                <when value="obiwarp">
+                    <section name="section_retcor_obiwarp_non_optimizable" title="Non optimizable parameters"  expanded="True">
+                        <param name="profStep" type="text" value="0.7,1.0" label="Range for Step size (in m/z)" help="[profStep] to use for profile generation from the raw data files (ex: 1 or 0.7 1.0)" />
+                    </section>
+                </when>
+                <when value="peakgroups">
+                    <section name="section_retcor_peakgroups_non_optimizable" title="Non optimizable parameters"  expanded="True">
+                        <param name="smooth" type="select" label="Smooth method" help="[smooth] only the 'loess’ for non-linear alignment is available so far" >
+                            <option value="loess">loess</option>
+                        </param>
+                        <param name="extra" type="integer" value="1" label="Number of extra peaks to allow in retention time correction correction groups" help="[extra]" />
+                        <param name="missing" type="integer" value="1" label="Number of missing samples to allow in retention time correction groups" help="[missing]" />
+                        <param name="span" type="float" value="0.2" label="Degree of smoothing for local polynomial regression fitting" help="[span]"/>
+                        <param name="family" type="select" label="Family" help="[family] if gaussian fitting is by least-squares with no outlier removal, and if symmetric a re descending M estimator is used with Tukey's biweight function, allowing outlier removal">
+                            <option value="gaussian" selected="true">gaussian</option>
+                            <option value="symmetric">symmetric</option>
+                        </param>
+                        <param name="plottype" type="select" help="[plottype] if deviation plot retention time deviation points and regression fit, and if mdevden also plot peak overall peak density and retention time correction peak density">
+                            <option value="none" selected="true">none</option>
+                            <option value="deviation">deviation</option>
+                            <option value="mdevden">mdevden</option>
+                        </param>
+                    </section>
+                </when>
+            </conditional>
+
+        </section>
+
+        <expand macro="input_file_load"/>
+
+    </inputs>
+
+    <outputs>
+        <data name="parametersOutput" format="tabular" label="IPO_parameters4retcorGroup.tsv" />
+        <data name="log" format="txt" label="ipo4retcor.log.txt" />
+    </outputs>
+
+    <tests>
+        <!-- TOO LONG
+        <test>
+            <param name="image" value="faahKO.xset.RData"/>
+            <param name="group|methods|method" value="density"/>
+            <param name="group|methods|bw" value="28,32"/>
+            <param name="group|methods|minfrac" value="1"/>
+            <param name="group|methods|mzwid" value="0.15,0.35"/>
+            <param name="retcor|methods|method" value="peakgroups"/>
+            <param name="retcor|methods|smooth" value="loess"/>
+            <param name="retcor|methods|extra" value="1"/>
+            <param name="retcor|methods|missing" value="1"/>
+            <expand macro="test_file_load_zip"/>
+            <output name="parametersOutput" file="faahKO_IPO_parameters4retgroup.tsv" />
+        </test>-->
+
+        <test>
+            <param name="image" value="faahKO.xset.RData"/>
+            <section name="group">
+                <conditional name="methods">
+                    <param name="method" value="density"/>
+                    <section name="section_group_density_optiomizable">
+                        <conditional name="conditional_parameter">
+                            <param name="bw" value="28,32"/>
+                            <param name="mzwid" value="0.25"/>
+                        </conditional>
+                    </section>
+                    <section name="section_group_density_non_optimizable">
+                        <param name="minfrac" value="1"/>
+                    </section>
+                </conditional>
+            </section>
+            <section name="retcor">
+                <conditional name="methods">
+                    <param name="retcormethod" value="peakgroups"/>
+                    <section name="section_retcor_peakgroups_non_optimizable">
+                        <param name="smooth" value="loess"/>
+                        <param name="rextra" value="1"/>
+                        <param name="missing" value="1"/>
+                    </section>
+                </conditional>
+            </section>
+            <expand macro="test_file_load_zip"/>
+            <output name="parametersOutput" file="faahKO_IPO_parameters4retgroup_bw.tsv" />
+        </test>
+
+        <!--<test>
+            <param name="image" value="faahKO.xset.RData"/>
+            <param name="group|methods|method" value="density"/>
+            <param name="group|methods|bw" value="30"/>
+            <param name="group|methods|minfrac" value="1"/>
+            <param name="group|methods|mzwid" value="0.15,0.35"/>
+            <param name="retcor|methods|retcormethod" value="peakgroups"/>
+            <param name="retcor|methods|smooth" value="loess"/>
+            <param name="retcor|methods|extra" value="1"/>
+            <param name="retcor|methods|missing" value="1"/>
+            <expand macro="test_file_load_zip"/>
+            <output name="parametersOutput" file="faahKO_IPO_parameters4retgroup_mzmid.tsv" />
+        </test>-->
+
+        <!--<test>
+            <param name="image" value="MM-xset-merge.RData"/>
+            <param name="group|methods|method" value="density"/>
+            <param name="group|methods|bw" value="22,38"/>
+            <param name="group|methods|minfrac" value="1"/>
+            <param name="group|methods|mzwid" value="0.015,0.035"/>
+            <param name="retcor|methods|retcormethod" value="peakgroups"/>
+            <param name="retcor|methods|smooth" value="loess"/>
+            <param name="retcor|methods|extra" value="1"/>
+            <param name="retcor|methods|missing" value="1"/>
+            <param name="file_load_conditional|file_load_select" value="yes" />
+            <expand macro="test_file_load_single"/>
+            <output name="parametersOutput" file="MM_IPO_parameters4retgroup.tsv" />
+        </test>-->
+    </tests>
+
+    <help><![CDATA[
+
+@HELP_AUTHORS@
+
+===============
+IPO.ipo4xcmsSet
+===============
+
+-----------
+Description
+-----------
+
+A Tool for automated Optimization of XCMS Parameters
+
+
+-----------------
+Workflow position
+-----------------
+
+**Upstream tools**
+
+========================= ================= ======= =========
+Name                      output file       format  parameter
+========================= ================= ======= =========
+NA                        NA                zip     NA
+========================= ================= ======= =========
+
+
+**Downstream tools**
+
++---------------------------+----------------------+-----------------+
+| Name                      | Output file          | Format          |
++===========================+======================+=================+
+|xcms.xcmsSet               | parametersOutput.tsv | Tabular         |
++---------------------------+--------------------+-------------------+
+
+
+
+-----------
+Input files
+-----------
+
++---------------------------+------------+
+| Parameter : num + label   |   Format   |
++===========================+============+
+| 1 : Choose your inputs    |   zip      |
++---------------------------+------------+
+
+**Choose your inputs**
+
+You have two methods for your inputs:
+
+    | Zip file (recommended): You can put a zip file containing your inputs: myinputs.zip (containing all your conditions as sub-directories).
+    | library folder: You must specify the name of your "library" (folder) created within your space project (for example: /projet/externe/institut/login/galaxylibrary/yourlibrary). Your library must contain all your conditions as sub-directories.
+
+Steps for creating the zip file
+-------------------------------
+
+**Step1: Creating your directory and hierarchize the subdirectories**
+
+
+VERY IMPORTANT: If you zip your files under Windows, you must use the 7Zip software (http://www.7-zip.org/), otherwise your zip will not be well unzipped on the platform W4M (zip corrupted bug).
+
+Your zip should contain all your conditions as sub-directories. For example, two conditions (mutant and wild):
+arabidopsis/wild/01.raw
+arabidopsis/mutant/01.raw
+
+**Step2: Creating a zip file**
+
+Create your zip file (e.g.: arabidopsis.zip).
+
+**Step 3 : Uploading it to our Galaxy server**
+
+If your zip file is less than 2Gb, you get use the Get Data tool to upload it.
+
+Otherwise if your zip file is larger than 2Gb, please refer to the HOWTO on workflow4metabolomics.org (http://application.sb-roscoff.fr/download/w4m/howto/galaxy_upload_up_2Go.pdf).
+
+For more informations, don't hesitate to send us an email at supportATworkflow4metabolomics.org).
+
+Advices for converting your files for the XCMS input
+----------------------------------------------------
+
+We recommend you to convert your raw files to **mzXML** in centroid mode (smaller files) and the files will be compatible with the xmcs centWave method.
+
+**We recommend you the following parameters:**
+
+Use Filtering: **True**
+
+Use Peak Picking: **True**
+
+Peak Peaking -Apply to MS Levels: **All Levels (1-)** : Centroid Mode
+
+Use zlib: **64**
+
+Binary Encoding: **64**
+
+m/z Encoding: **64**
+
+Intensity Encoding: **64**
+
+
+----------
+Parameters
+----------
+
+Extraction method for peaks detection
+-------------------------------------
+
+**Matched Filter**
+
+    | One parameter to consider is the Gaussian model peak width used for matched filtration,an integral part of the peak detection algorithm.
+    | For a discussion of how model peak width affects the signal to noise ratio, see Danielsson et al. (2002).
+
+
+**cent Wave**
+
+    | This algorithm is most suitable for high resolution LC/{TOF,OrbiTrap,FTICR}-MS data in centroid mode.
+    | Due to the fact that peak centroids are used, a binning step is not necessary.
+    | The method is capable of detecting close-by-peaks and also overlapping peaks. Some efforts are made to detect the exact peak boundaries to get precise peak integrals.
+
+
+------------
+Output files
+------------
+
+IPO_parameters4retcorGroup.tsv
+
+    | Optimal parameters for xcmsSet
+
+
+
+---------------------------------------------------
+
+Changelog/News
+--------------
+
+
+
+    ]]></help>
+
+    <expand macro="citation" />
+</tool>

--- a/tools/phenomenal/ms/ipo/ipo4xcmsSet.xml
+++ b/tools/phenomenal/ms/ipo/ipo4xcmsSet.xml
@@ -1,6 +1,6 @@
 <tool id="ipo4xcmsSet" name="IPO for xcmsSet" version="0.0.3">
 
-    <description>IPO optimization process for xcms.xcmsSet</description>
+    <description>IPO optimization process for peak picking</description>
 
     <macros>
         <import>macros.xml</import>
@@ -250,58 +250,72 @@
 IPO.ipo4xcmsSet
 ===============
 
+|
+
 -----------
 Description
 -----------
 
-A Tool for automated Optimization of XCMS Parameters
-
+**IPO for xcmsSet**  This tool optimizes peak picking parameters for XCMS
 
 -----------------
 Workflow position
------------------
+-----------------  
+
+|
 
 **Upstream tools**
 
-========================= ================= ======= =========
-Name                      output file       format  parameter
-========================= ================= ======= =========
-NA                        NA                zip     NA
-========================= ================= ======= =========
+========================= ============== ======== ===========
+ Name                      output file    format   parameter
+========================= ============== ======== ===========
+ NA                        NA             NA       NA
+========================= ============== ======== ===========  
 
+|
 
 **Downstream tools**
 
-+---------------------------+----------------------+-----------------+
-| Name                      | Output file          | Format          |
-+===========================+======================+=================+
-|xcms.xcmsSet               | parametersOutput.tsv | Tabular         |
-+---------------------------+--------------------+-------------------+
++---------------------------+--------------------------------+-----------------+
+| Name                      | Output file                    | Format          |
++===========================+================================+=================+
+| ipo4retgroup              | IPO_parameters4retcorGroup.tsv | Tabular         |
++---------------------------+--------------------------------+-----------------+  
 
-
+|
 
 -----------
 Input files
------------
+-----------  
 
-+---------------------------+------------+
-| Parameter : num + label   |   Format   |
-+===========================+============+
-| 1 : Choose your inputs    |   zip      |
-+---------------------------+------------+
+|
+
++---------------------------+---------------------------------------+
+| Parameter : num + label   |   Format                              |
++===========================+=======================================+
+| 1 : Choose your inputs    |   zip, mzML, mzXML, mzData, netCDF    |
++---------------------------+---------------------------------------+  
+
+|
 
 **Choose your inputs**
 
-You have two methods for your inputs:
+You have three methods for your inputs:
 
     | Zip file (recommended): You can put a zip file containing your inputs: myinputs.zip (containing all your conditions as sub-directories).
     | library folder: You must specify the name of your "library" (folder) created within your space project (for example: /projet/externe/institut/login/galaxylibrary/yourlibrary). Your library must contain all your conditions as sub-directories.
+    | MZ file: You can give only one mz file (mzData, mzML, mzXML, netCDF) as input.
+
+|
 
 Steps for creating the zip file
 -------------------------------
 
+|
+
 **Step1: Creating your directory and hierarchize the subdirectories**
 
+|
 
 VERY IMPORTANT: If you zip your files under Windows, you must use the 7Zip software (http://www.7-zip.org/), otherwise your zip will not be well unzipped on the platform W4M (zip corrupted bug).
 
@@ -342,30 +356,39 @@ m/z Encoding: **64**
 
 Intensity Encoding: **64**
 
+|
 
 ----------
 Parameters
 ----------
 
+|
+
 Extraction method for peaks detection
 -------------------------------------
+
+|
 
 **Matched Filter**
 
     | One parameter to consider is the Gaussian model peak width used for matched filtration,an integral part of the peak detection algorithm.
     | For a discussion of how model peak width affects the signal to noise ratio, see Danielsson et al. (2002).
 
+|
 
-**cent Wave**
+**Cent Wave**
 
     | This algorithm is most suitable for high resolution LC/{TOF,OrbiTrap,FTICR}-MS data in centroid mode.
     | Due to the fact that peak centroids are used, a binning step is not necessary.
     | The method is capable of detecting close-by-peaks and also overlapping peaks. Some efforts are made to detect the exact peak boundaries to get precise peak integrals.
 
+|
 
 ------------
 Output files
 ------------
+
+|
 
 IPO_parameters4xcmsSet.tsv
 
@@ -374,6 +397,19 @@ IPO_parameters4xcmsSet.tsv
 resultPeakpicking.RData
 
     | Peak picking results with R objects
+
+best_xcmsSet.RData
+
+    | Best xcmsSet R object to give as input for the next tool: ipo4retgroup
+
+run_instrument_infos.tsv
+
+    | Informations about the instrument(s), manufacturer(s), experimental run, gathered from the input mz file(s) so that you can see any difference if there is any.
+
+
+.. class:: infomark
+
+You can continue your analysis with *IPO for group and retcor*.
 
 
 ---------------------------------------------------
@@ -387,3 +423,4 @@ Changelog/News
 
     <expand macro="citation" />
 </tool>
+

--- a/tools/phenomenal/ms/ipo/ipo4xcmsSet.xml
+++ b/tools/phenomenal/ms/ipo/ipo4xcmsSet.xml
@@ -164,8 +164,8 @@
     </inputs>
 
     <outputs>
-        <data name="best_xcmsSet" from_work_dir="./best_xcmsSet.RData" format="rdata" label="best_xcmsSet.RData" />
         <data name="resultPeakpicking" format="rdata" label="resultPeakpicking.RData" />
+        <data name="best_xcmsSet" from_work_dir="./best_xcmsSet.RData" format="rdata" label="best_xcmsSet.RData" />
         <data name="parametersOutput" format="tabular" label="IPO_parameters4xcmsSet.tsv" />
         <data name="run_instrument_infos" from_work_dir="./run_instrument_infos.tsv" format="tabular" label="run_instrument_infos.tsv" />
         <data name="log" format="txt" label="ipo4xcmsSet.log.txt" />

--- a/tools/phenomenal/ms/ipo/ipo4xcmsSet.xml
+++ b/tools/phenomenal/ms/ipo/ipo4xcmsSet.xml
@@ -30,10 +30,10 @@
     <command><![CDATA[
         LANG=C ipo4xcmsSet.r
 
-        #if $input.is_of_type("mzxml") or $input.is_of_type("mzml") or $input.is_of_type("mzdata") or $input.is_of_type("netcdf"):
-            singlefile_galaxyPath '$input' singlefile_sampleName '$input.name'
+        #if $ipo4xcmsSet_input.is_of_type("mzxml") or $ipo4xcmsSet_input.is_of_type("mzml") or $ipo4xcmsSet_input.is_of_type("mzdata") or $ipo4xcmsSet_input.is_of_type("netcdf"):
+            singlefile_galaxyPath '$ipo4xcmsSet_input' singlefile_sampleName '$ipo4xcmsSet_input.name'
         #else
-            zipfile '$input'
+            zipfile '$ipo4xcmsSet_input'
         #end if
 
         parametersOutput $parametersOutput
@@ -71,7 +71,7 @@
 
     <inputs>
 
-        <param name="input" type="data" format="mzxml,mzml,mzdata,netcdf,no_unzip.zip,zip" label="File(s) from your history containing your chromatograms" help="Single file mode for the format: mzxml, mzml, mzdata and netcdf. Zip file mode for the format: no_unzip.zip, zip. See the help section below." />
+        <param name="ipo4xcmsSet_input" type="data" format="mzxml,mzml,mzdata,netcdf,no_unzip.zip,zip" label="File(s) from your history containing your chromatograms" help="Single file mode for the format: mzxml, mzml, mzdata and netcdf. Zip file mode for the format: no_unzip.zip, zip. See the help section below." />
 
         <param name="samplebyclass" type="integer" value="2" label="Number of samples used per class to estimate the best parameters" help="Set to 0 to use the whole dataset. To save time, reduce this number" />
 
@@ -173,7 +173,7 @@
 
     <tests>
         <test>
-            <param name="input" value="MM14.mzML"  ftype="mzxml" />
+            <param name="ipo4xcmsSet_input" value="MM14.mzML"  ftype="mzxml" />
             <param name="samplebyclass" value="0" />
             <conditional name="methods">
                 <param name="method" value="centWave" />
@@ -190,7 +190,7 @@
             <output name="parametersOutput" file="MM14_IPO_parameters4xcmsSet_peakwidth.tsv" />
         </test>
         <test>
-            <param name="input" value="MM14.mzML"  ftype="mzxml" />
+            <param name="ipo4xcmsSet_input" value="MM14.mzML"  ftype="mzxml" />
             <param name="samplebyclass" value="0" />
             <conditional name="methods">
                 <param name="method" value="centWave" />
@@ -208,7 +208,7 @@
         </test>
         <!-- Too long for Travis CI -->
         <!--<test>
-            <param name="inputs|input" value="zip_file" />
+            <param name="inputs|ipo4xcmsSet_input" value="zip_file" />
             <param name="inputs|zip_file" value="sacuri_2files.zip"  ftype="zip" />
             <param name="samplebyclass" value="1" />
             <param name="methods|method" value="centWave" />
@@ -219,7 +219,7 @@
         </test>-->
         <!-- Too long for Travis CI -->
         <!--<test>
-            <param name="inputs|input" value="zip_file" />
+            <param name="inputs|ipo4xcmsSet_input" value="zip_file" />
             <param name="inputs|zip_file" value="sacuri_2files.zip"  ftype="zip" />
             <param name="samplebyclass" value="1" />
             <param name="methods|method" value="matchedFilter" />
@@ -231,7 +231,7 @@
                 Error in resultIncreased(history) :
                         No isotopes have been detected, peak picking not optimizable by IPO!-->
         <!--<test>
-            <param name="inputs|input" value="zip_file" />
+            <param name="inputs|ipo4xcmsSet_input" value="zip_file" />
             <param name="inputs|zip_file" value="faahKO_reduce.zip"  ftype="zip" />
             <param name="methods|method" value="centWave" />
             <param name="methods|ppm" value="25" />
@@ -423,4 +423,3 @@ Changelog/News
 
     <expand macro="citation" />
 </tool>
-

--- a/tools/phenomenal/ms/ipo/ipo4xcmsSet.xml
+++ b/tools/phenomenal/ms/ipo/ipo4xcmsSet.xml
@@ -1,0 +1,389 @@
+<tool id="ipo4xcmsSet" name="IPO for xcmsSet" version="0.0.3">
+
+    <description>IPO optimization process for xcms.xcmsSet</description>
+
+    <macros>
+        <import>macros.xml</import>
+
+        <macro name="centwave_ppm_fixed">
+            <param name="ppm" type="integer" value="25" label="Max tolerated ppm m/z deviation in consecutive scans in ppm" help="[ppm]" />
+        </macro>
+        <macro name="centwave_peakwidth_fixed">
+            <param name="min_peakwidth" type="float" value="20" label="Min peak width range in seconds" optional="true" help="[min_peakwidth]" />
+            <param name="max_peakwidth" type="float" value="50" label="Max peak width range in seconds" optional="true" help="[max_peakwidth]" />
+        </macro>
+        <macro name="centwave_mzdiff_fixed">
+            <param name="mzdiff" type="float" value="-0.001" label="Minimum difference in m/z for peaks with overlapping Retention Times" help="[mzdiff] Can be negative to allow overlap" />
+        </macro>
+
+        <macro name="matchedfilter_fwhm_fixed">
+            <param name="fwhm" type="integer" value="30" label="Full width at half maximum of matched filtration gaussian model peak" help="[fwhm] Only used to calculate the actual sigma" />
+        </macro>
+        <macro name="matchedfilter_mzdiff_fixed">
+            <param name="mzdiff" type="float" value="0.6" label="Minimum difference in m/z for peaks with overlapping Retention Times" help="[mzdiff] By default: 0.8-step*steps " />
+        </macro>
+    </macros>
+
+    <expand macro="requirements"/>
+    <expand macro="stdio"/>
+
+    <command><![CDATA[
+        LANG=C ipo4xcmsSet.r
+
+        #if $input.is_of_type("mzxml") or $input.is_of_type("mzml") or $input.is_of_type("mzdata") or $input.is_of_type("netcdf"):
+            singlefile_galaxyPath '$input' singlefile_sampleName '$input.name'
+        #else
+            zipfile '$input'
+        #end if
+
+        parametersOutput $parametersOutput
+        
+        optimResultsRdataOutput $resultPeakpicking
+
+        samplebyclass $samplebyclass
+
+        ## profmethod $profmethod
+        @COMMAND_NSLAVES@
+        method $methods.method
+        #if $methods.method == "centWave":
+            ppm "c($methods.section_centwave_optiomizable.conditional_parameter.ppm)"
+            min_peakwidth "c($methods.section_centwave_optiomizable.conditional_parameter.min_peakwidth)"
+            max_peakwidth "c($methods.section_centwave_optiomizable.conditional_parameter.max_peakwidth)"
+            mzdiff "c($methods.section_centwave_optiomizable.conditional_parameter.mzdiff)"
+
+            snthresh $methods.section_centwave_non_optiomizable.snthresh
+            integrate $methods.section_centwave_non_optiomizable.integrate
+            noise $methods.section_centwave_non_optiomizable.noise
+            prefilter "c($methods.section_centwave_non_optiomizable.prefilter)"
+
+        #elif $methods.method == "matchedFilter":
+            fwhm "c($methods.section_matchedfilter_optiomizable.conditional_parameter.fwhm)"
+            mzdiff "c($methods.section_matchedfilter_optiomizable.conditional_parameter.mzdiff)"
+
+            step $methods.section_matchedfilter_non_optimizable.step
+            steps $methods.section_matchedfilter_non_optimizable.steps
+            max $methods.section_matchedfilter_non_optimizable.max
+            snthresh $methods.section_matchedfilter_non_optimizable.snthresh
+        #end if
+
+        @COMMAND_LOG_EXIT@
+    ]]></command>
+
+    <inputs>
+
+        <param name="input" type="data" format="mzxml,mzml,mzdata,netcdf,no_unzip.zip,zip" label="File(s) from your history containing your chromatograms" help="Single file mode for the format: mzxml, mzml, mzdata and netcdf. Zip file mode for the format: no_unzip.zip, zip. See the help section below." />
+
+        <param name="samplebyclass" type="integer" value="2" label="Number of samples used per class to estimate the best parameters" help="Set to 0 to use the whole dataset. To save time, reduce this number" />
+
+        <conditional name="methods">
+            <param name="method" type="select" label="Extraction method for peaks detection" help="[method] See the help section below">
+                <option value="centWave" >centWave</option>
+                <option value="matchedFilter" selected="true">matchedFilter</option>
+            </param>
+
+            <!-- centWave Filter options -->
+            <when value="centWave">
+                <section name="section_centwave_optiomizable"  title="Optimizable parameters" expanded="True">
+                    <conditional name="conditional_parameter">
+                        <param name="select_parameter" type="select" label="Which parameter do you want to optimize?" help="Only one paramter can be optimized at once. The other will require fixed values">
+                            <option value="ppm">Max tolerated ppm m/z deviation in consecutive scans in ppm [ppm]</option>
+                            <option value="peakwidth">Min,Max peak width in seconds [peakwidth]</option>
+                            <option value="mzdiff">Minimum difference in m/z for peaks with overlapping Retention Times [mzdiff]</option>
+                        </param>
+                        <when value="ppm">
+                            <param name="ppm" type="text" value="17,32" label="Range for Max tolerated ppm m/z deviation in consecutive scans in ppm" optional="false" help="[ppm] (ex: 25 or 17,32)">
+                                <validator type="regex" message="Should be this format XX,YY">[0-9]+,[0-9]+</validator>
+                            </param>
+                            <expand macro="centwave_peakwidth_fixed" />
+                            <expand macro="centwave_mzdiff_fixed" />
+                        </when>
+                        <when value="peakwidth">
+                            <param name="min_peakwidth" type="text" value="12,18" label="Range for Min peak width range in seconds" optional="true" help="[min_peakwidth] (ex: 12,18)">
+                                <validator type="regex" message="Should be one combinaison of those format: XX,YY or XX.XX,YY.YY">[0-9]+[\.]?[0-9]*,[0-9]+[\.]?[0-9]*</validator>
+                            </param>
+                            <param name="max_peakwidth" type="text" value="35,65" label="Range for Max peak width range in seconds" optional="true" help="[max_peakwidth] (ex: 35,65)">
+                                <validator type="regex" message="Should be one combinaison of those format: XX,YY or XX.XX,YY.YY">[0-9]+[\.]?[0-9]*,[0-9]+[\.]?[0-9]*</validator>
+                            </param>
+                            <expand macro="centwave_ppm_fixed" />
+                            <expand macro="centwave_mzdiff_fixed" />
+                        </when>
+                        <when value="mzdiff">
+                            <param name="mzdiff" type="text" value="-0.001,0.010" label="Range for Minimum difference in m/z for peaks with overlapping retention times" help="[mzdiff] Can be negative to allow overlap (ex: -0.001,0.010)">
+                                <validator type="regex" message="Should be one combinaison of those format: XX,YY or -XX,YY or XX.XX,YY.YY">[\-]?[0-9]+[\.]?[0-9]*,[\-]?[0-9]+[\.]?[0-9]*</validator>
+                            </param>
+                            <expand macro="centwave_ppm_fixed" />
+                            <expand macro="centwave_peakwidth_fixed" />
+                        </when>
+                    </conditional>
+                </section>
+
+                <section name="section_centwave_non_optiomizable"  title="Non optimizable parameters" expanded="True">
+                    <param name="snthresh" type="integer" value="10" label="Signal/Noise threshold" help="[snthresh] Signal to noise ratio cutoff" />
+                    <param name="integrate" type="select" label="Peak limits method" help="[integrate]" >
+                        <option value="1">peak limits based on smoothed 2nd derivative (less precise)</option>
+                        <option value="2">peak limits based on real data (more sensitive to noise)</option>
+                    </param>
+                    <param name="prefilter" type="text" value="3,100" label="Prefilter step for the first phase" help="[prefilter] Separate by coma k,I. Mass traces are only retained if they contain at least ‘k’ peaks with intensity >= ‘I’"/>
+                    <param name="noise" type="integer" value="0" label="Noise filter" help="[noise] optional argument which is useful for data that was centroided without any intensity threshold, centroids with intensity smaller than ‘noise’ are omitted from ROI detection"/>
+                </section>
+            </when>
+
+            <!-- matched Filter options -->
+            <when value="matchedFilter">
+                <section name="section_matchedfilter_optiomizable"  title="Optimizable parameters" expanded="True">
+                    <conditional name="conditional_parameter">
+                        <param name="select_parameter" type="select" label="Which parameter do you want to optimize?" help="Only one paramter can be optimized at once. The other will require fixed values">
+                            <option value="fwhm">Full width at half maximum of matched filtration gaussian model peak [fwhm]</option>
+                            <option value="mzdiff">Minimum difference in m/z for peaks with overlapping Retention Times [mzdiff]</option>
+                        </param>
+                        <when value="fwhm">
+                            <param name="fwhm" type="text" value="25,35" label="Range for Full width at half maximum of matched filtration gaussian model peak" optional="true" help="[fwhm] Only used to calculate the actual sigma (ex: 25,35)">
+                                <validator type="regex" message="Should be this format: XX,YY">[0-9]+,[0-9]+</validator>
+                            </param>
+                            <expand macro="matchedfilter_mzdiff_fixed" />
+                        </when>
+                        <when value="mzdiff">
+                            <param name="mzdiff" type="text" value="0.4,0.7" label="Range for Minimum difference in m/z for peaks with overlapping Retention Times" help="[mzdiff] By default: 0.8-step*steps (ex: 0.4,0.7)">
+                                <validator type="regex" message="Should be one combinaison of those format: XX,YY or -XX,YY or XX.XX,YY.YY">[\-]?[0-9]+[\.]?[0-9]*,[\-]?[0-9]+[\.]?[0-9]*</validator>
+                            </param>
+                            <expand macro="matchedfilter_fwhm_fixed" />
+                        </when>
+                    </conditional>
+                </section>
+
+                <section name="section_matchedfilter_non_optimizable" title="Non optimizable parameters"  expanded="True">
+                    <param name="step" type="float" value="0.1" label="Step size to use for profile generation" help="[step] The peak detection algorithm creates extracted ion base peak chromatograms (EIBPC) on a fixed step size" />
+                    <param name="steps" type="integer" value="2" label="Number of steps to merge prior to filtration" help="[steps] The peak identification algorithm combines a given number of EIBPCs prior to filtration and peak detection, as defined by the steps argument" />
+                    <param name="max" type="integer" value="5" label="Maximum number of peaks per extracted ion chromatogram" help="[max]" />
+                    <param name="snthresh" type="integer" value="10" label="Signal to noise ratio cutoff" help="[snthresh]" />
+                </section>
+            </when>
+        </conditional>
+
+
+    </inputs>
+
+    <outputs>
+        <data name="best_xcmsSet" from_work_dir="./best_xcmsSet.RData" format="rdata" label="best_xcmsSet.RData" />
+        <data name="resultPeakpicking" format="rdata" label="resultPeakpicking.RData" />
+        <data name="parametersOutput" format="tabular" label="IPO_parameters4xcmsSet.tsv" />
+        <data name="run_instrument_infos" from_work_dir="./run_instrument_infos.tsv" format="tabular" label="run_instrument_infos.tsv" />
+        <data name="log" format="txt" label="ipo4xcmsSet.log.txt" />
+    </outputs>
+
+    <tests>
+        <test>
+            <param name="input" value="MM14.mzML"  ftype="mzxml" />
+            <param name="samplebyclass" value="0" />
+            <conditional name="methods">
+                <param name="method" value="centWave" />
+                <section name="section_centwave_optiomizable" >
+                    <conditional name="conditional_parameter">
+                        <param name="select_parameter" value="peakwidth" />
+                        <param name="min_peakwidth" value="3,9.5" />
+                        <param name="max_peakwidth" value="10,20" />
+                        <param name="ppm" value="56" />
+                        <param name="mzdiff" value="-0.001" />
+                    </conditional>
+                </section>
+            </conditional>
+            <output name="parametersOutput" file="MM14_IPO_parameters4xcmsSet_peakwidth.tsv" />
+        </test>
+        <test>
+            <param name="input" value="MM14.mzML"  ftype="mzxml" />
+            <param name="samplebyclass" value="0" />
+            <conditional name="methods">
+                <param name="method" value="centWave" />
+                <section name="section_centwave_optiomizable" >
+                    <conditional name="conditional_parameter">
+                        <param name="select_parameter" value="ppm" />
+                        <param name="ppm" value="50,60" />
+                        <param name="min_peakwidth" value="3.325" />
+                        <param name="max_peakwidth" value="11" />
+                        <param name="mzdiff" value="-0.001" />
+                    </conditional>
+                </section>
+            </conditional>
+            <output name="parametersOutput" file="MM14_IPO_parameters4xcmsSet_ppm.tsv" />
+        </test>
+        <!-- Too long for Travis CI -->
+        <!--<test>
+            <param name="inputs|input" value="zip_file" />
+            <param name="inputs|zip_file" value="sacuri_2files.zip"  ftype="zip" />
+            <param name="samplebyclass" value="1" />
+            <param name="methods|method" value="centWave" />
+            <param name="methods|ppm" value="25" />
+            <param name="methods|min_peakwidth" value="20,30" />
+            <param name="methods|max_peakwidth" value="45,55" />
+            <output name="parametersOutput" file="sacuri_2files_centWave_IPO_parameters4xcmsSet.tsv" />
+        </test>-->
+        <!-- Too long for Travis CI -->
+        <!--<test>
+            <param name="inputs|input" value="zip_file" />
+            <param name="inputs|zip_file" value="sacuri_2files.zip"  ftype="zip" />
+            <param name="samplebyclass" value="1" />
+            <param name="methods|method" value="matchedFilter" />
+            <param name="methods|step" value="0.05,0.15" />
+            <param name="methods|fwhm" value="25,35" />
+            <output name="parametersOutput" file="sacuri_2files_matchedFilter_IPO_parameters4xcmsSet.tsv" />
+        </test>-->
+        <!--Failed:
+                Error in resultIncreased(history) :
+                        No isotopes have been detected, peak picking not optimizable by IPO!-->
+        <!--<test>
+            <param name="inputs|input" value="zip_file" />
+            <param name="inputs|zip_file" value="faahKO_reduce.zip"  ftype="zip" />
+            <param name="methods|method" value="centWave" />
+            <param name="methods|ppm" value="25" />
+            <param name="methods|min_peakwidth" value="15,25" />
+            <param name="methods|min_peakwidth" value="20,30" />
+            <param name="methods|max_peakwidth" value="45,55" />
+            <output name="parametersOutput" file="faahKO_IPO_parameters4xcmsSet.tsv" />
+        </test>-->
+    </tests>
+
+    <help><![CDATA[
+
+@HELP_AUTHORS@
+
+===============
+IPO.ipo4xcmsSet
+===============
+
+-----------
+Description
+-----------
+
+A Tool for automated Optimization of XCMS Parameters
+
+
+-----------------
+Workflow position
+-----------------
+
+**Upstream tools**
+
+========================= ================= ======= =========
+Name                      output file       format  parameter
+========================= ================= ======= =========
+NA                        NA                zip     NA
+========================= ================= ======= =========
+
+
+**Downstream tools**
+
++---------------------------+----------------------+-----------------+
+| Name                      | Output file          | Format          |
++===========================+======================+=================+
+|xcms.xcmsSet               | parametersOutput.tsv | Tabular         |
++---------------------------+--------------------+-------------------+
+
+
+
+-----------
+Input files
+-----------
+
++---------------------------+------------+
+| Parameter : num + label   |   Format   |
++===========================+============+
+| 1 : Choose your inputs    |   zip      |
++---------------------------+------------+
+
+**Choose your inputs**
+
+You have two methods for your inputs:
+
+    | Zip file (recommended): You can put a zip file containing your inputs: myinputs.zip (containing all your conditions as sub-directories).
+    | library folder: You must specify the name of your "library" (folder) created within your space project (for example: /projet/externe/institut/login/galaxylibrary/yourlibrary). Your library must contain all your conditions as sub-directories.
+
+Steps for creating the zip file
+-------------------------------
+
+**Step1: Creating your directory and hierarchize the subdirectories**
+
+
+VERY IMPORTANT: If you zip your files under Windows, you must use the 7Zip software (http://www.7-zip.org/), otherwise your zip will not be well unzipped on the platform W4M (zip corrupted bug).
+
+Your zip should contain all your conditions as sub-directories. For example, two conditions (mutant and wild):
+arabidopsis/wild/01.raw
+arabidopsis/mutant/01.raw
+
+**Step2: Creating a zip file**
+
+Create your zip file (e.g.: arabidopsis.zip).
+
+**Step 3 : Uploading it to our Galaxy server**
+
+If your zip file is less than 2Gb, you get use the Get Data tool to upload it.
+
+Otherwise if your zip file is larger than 2Gb, please refer to the HOWTO on workflow4metabolomics.org (http://application.sb-roscoff.fr/download/w4m/howto/galaxy_upload_up_2Go.pdf).
+
+For more informations, don't hesitate to send us an email at supportATworkflow4metabolomics.org).
+
+Advices for converting your files for the XCMS input
+----------------------------------------------------
+
+We recommend you to convert your raw files to **mzXML** in centroid mode (smaller files) and the files will be compatible with the xmcs centWave method.
+
+**We recommend you the following parameters:**
+
+Use Filtering: **True**
+
+Use Peak Picking: **True**
+
+Peak Peaking -Apply to MS Levels: **All Levels (1-)** : Centroid Mode
+
+Use zlib: **64**
+
+Binary Encoding: **64**
+
+m/z Encoding: **64**
+
+Intensity Encoding: **64**
+
+
+----------
+Parameters
+----------
+
+Extraction method for peaks detection
+-------------------------------------
+
+**Matched Filter**
+
+    | One parameter to consider is the Gaussian model peak width used for matched filtration,an integral part of the peak detection algorithm.
+    | For a discussion of how model peak width affects the signal to noise ratio, see Danielsson et al. (2002).
+
+
+**cent Wave**
+
+    | This algorithm is most suitable for high resolution LC/{TOF,OrbiTrap,FTICR}-MS data in centroid mode.
+    | Due to the fact that peak centroids are used, a binning step is not necessary.
+    | The method is capable of detecting close-by-peaks and also overlapping peaks. Some efforts are made to detect the exact peak boundaries to get precise peak integrals.
+
+
+------------
+Output files
+------------
+
+IPO_parameters4xcmsSet.tsv
+
+    | Optimal parameters for xcmsSet
+
+resultPeakpicking.RData
+
+    | Peak picking results with R objects
+
+
+---------------------------------------------------
+
+Changelog/News
+--------------
+
+
+
+    ]]></help>
+
+    <expand macro="citation" />
+</tool>

--- a/tools/phenomenal/ms/ipo/macros.xml
+++ b/tools/phenomenal/ms/ipo/macros.xml
@@ -13,10 +13,6 @@
         </stdio>
     </xml>
 
-    <token name="@COMMAND_SCRIPT@">
-        LANG=C Rscript $__tool_directory__/
-    </token>
-
     <token name="@COMMAND_LOG_EXIT@">
         ;
         return=\$?;
@@ -79,7 +75,6 @@
     </xml>
 
     <token name="@HELP_AUTHORS@">
-
 .. class:: infomark
 
 **Authors**  Gunnar Libiseller, Michaela Dvorzak, Ulrike Kleb, Edgar Gander, Tobias Eisenberg, Frank Madeo, Steffen Neumann, Gert Trausinger, Frank Sinner, Thomas Pieber and Christoph Magnes
@@ -91,6 +86,7 @@
 .. class:: infomark
 
 **PhenoMeNal integration**  Gabriel Cretin (gcretin@ipb-halle.de) Adapted the galaxy wrappers from W4M for the integration of the tool into PhenoMeNal
+
 
 ---------------------------------------------------
 

--- a/tools/phenomenal/ms/ipo/macros.xml
+++ b/tools/phenomenal/ms/ipo/macros.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<macros>
+    <xml name="requirements">
+        <requirements>
+            <requirement type="package" version="0.4_1">r-snow</requirement>
+            <requirement type="package" version="1.0.0">bioconductor-ipo</requirement>
+            <requirement type="package" version="1.1_4">r-batch</requirement>
+        </requirements>
+    </xml>
+    <xml name="stdio">
+        <stdio>
+            <exit_code range="1" level="fatal" />
+        </stdio>
+    </xml>
+
+    <token name="@COMMAND_SCRIPT@">
+        LANG=C Rscript $__tool_directory__/
+    </token>
+
+    <token name="@COMMAND_LOG_EXIT@">
+        ;
+        return=\$?;
+        mv log.txt $log;
+        cat $log;
+        sh -c "exit \$return"
+    </token>
+
+    <token name="@COMMAND_NSLAVES@">
+        nSlaves \${GALAXY_SLOTS:-1}
+    </token>
+
+    <!-- zipfile load for planemo test -->
+
+    <token name="@COMMAND_FILE_LOAD@">
+        #if $file_load_section.file_load_conditional.file_load_select == "yes":
+            #if $file_load_section.file_load_conditional.input[0].is_of_type("mzxml") or $file_load_section.file_load_conditional.input[0].is_of_type("mzml") or $file_load_section.file_load_conditional.input[0].is_of_type("mzdata") or $file_load_section.file_load_conditional.input[0].is_of_type("netcdf"):
+                #set singlefile_galaxyPath = ','.join( [ str( $single_file ) for $single_file in $file_load_section.file_load_conditional.input ] )
+                #set singlefile_sampleName = ','.join( [ str( $single_file.name ) for $single_file in $file_load_section.file_load_conditional.input ] )
+
+                singlefile_galaxyPath '$singlefile_galaxyPath' singlefile_sampleName '$singlefile_sampleName'
+            #else
+                zipfile '$file_load_section.file_load_conditional.input'
+            #end if
+        #end if
+    </token>
+
+    <xml name="input_file_load">
+        <section name="file_load_section" title="Resubmit your raw dataset or your zip file">
+            <conditional name="file_load_conditional">
+                <param name="file_load_select" type="select" label="Resubmit your dataset or your zip file" help="Use only if you get a message which say that your original dataset or zip file have been deleted on the server." >
+                    <option value="no" >no need</option>
+                    <option value="yes" >yes</option>
+                </param>
+                <when value="no">
+                </when>
+                <when value="yes">
+                    <param name="input" type="data" format="mzxml,mzml,mzdata,netcdf,no_unzip.zip,zip" multiple="true" label="File(s) from your history containing your chromatograms" help="Single file mode for the format: mzxml, mzml, mzdata and netcdf. Zip file mode for the format: no_unzip.zip, zip. See the help section below." />
+                </when>
+            </conditional>
+        </section>
+    </xml>
+
+    <xml name="test_file_load_zip">
+        <section name="file_load_section">
+            <conditional name="file_load_conditional">
+                <param name="file_load_select" value="yes" />
+                <param name="input" value="faahKO_reduce.zip" ftype="zip" />
+            </conditional>
+        </section>
+    </xml>
+
+    <xml name="test_file_load_single">
+        <section name="file_load_section">
+            <conditional name="file_load_conditional">
+                <param name="file_load_select" value="yes" />
+                <param name="input" value="wt15.CDF,ko16.CDF,ko15.CDF,wt16.CDF" ftype="netcdf" />
+            </conditional>
+        </section>
+    </xml>
+
+    <token name="@HELP_AUTHORS@">
+.. class:: infomark
+
+**Authors**  Gunnar Libiseller, Michaela Dvorzak, Ulrike Kleb, Edgar Gander, Tobias Eisenberg, Frank Madeo, Steffen Neumann, Gert Trausinger, Frank Sinner, Thomas Pieber and Christoph Magnes
+
+.. class:: infomark
+
+**Galaxy integration** ABiMS TEAM - UPMC/CNRS - Station biologique de Roscoff and Yann Guitton yann.guitton@oniris-nantes.fr - part of Workflow4Metabolomics.org [W4M]
+
+ | Contact support@workflow4metabolomics.org for any questions or concerns about the Galaxy implementation of this tool.
+
+---------------------------------------------------
+
+    </token>
+
+
+    <xml name="citation">
+        <citations>
+            <citation type="doi">10.1186/s12859-015-0562-8</citation>
+            <citation type="doi">10.1093/bioinformatics/btu813</citation>
+        </citations>
+    </xml>
+</macros>

--- a/tools/phenomenal/ms/ipo/macros.xml
+++ b/tools/phenomenal/ms/ipo/macros.xml
@@ -79,6 +79,7 @@
     </xml>
 
     <token name="@HELP_AUTHORS@">
+
 .. class:: infomark
 
 **Authors**  Gunnar Libiseller, Michaela Dvorzak, Ulrike Kleb, Edgar Gander, Tobias Eisenberg, Frank Madeo, Steffen Neumann, Gert Trausinger, Frank Sinner, Thomas Pieber and Christoph Magnes
@@ -87,7 +88,9 @@
 
 **Galaxy integration** ABiMS TEAM - UPMC/CNRS - Station biologique de Roscoff and Yann Guitton yann.guitton@oniris-nantes.fr - part of Workflow4Metabolomics.org [W4M]
 
- | Contact support@workflow4metabolomics.org for any questions or concerns about the Galaxy implementation of this tool.
+.. class:: infomark
+
+**PhenoMeNal integration**  Gabriel Cretin (gcretin@ipb-halle.de) Adapted the galaxy wrappers from W4M for the integration of the tool into PhenoMeNal
 
 ---------------------------------------------------
 


### PR DESCRIPTION
Hi,

Here are the config files + galaxy wrappers to integrate IPO in the phenomenal main instance.
The tool was tested successfully on a local minikube instance, and the ipo-container (https://github.com/phnmnl/container-ipo) also passes tests on Jenkins.
@pcm32 and @sneumann can you please check if everything is ok / anything is missing ?

Yours,
Gabriel

**1 known issue**
For some unknown reason, the option below (which appears as the last option available on every tool in galaxy toolshed) does not appear for the tool "ipo4xcmsSet", but does appear for "ipo4retgroup". Perhaps a config file is faulty but I couldn't find where.

![image](https://user-images.githubusercontent.com/25644865/38806491-b9a9976a-4179-11e8-8421-7ed7432db38d.png)