### PR TITLE
Moves to Galaxy branch with latest fix for improved job restart handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Clone galaxy into /galaxy directory
-RUN git clone --depth 1 --single-branch --branch release_17.09_plus_isa_k8s_resource_limts https://github.com/phnmnl/galaxy.git
+RUN git clone --depth 1 --single-branch --branch release_17.09_isa_k8s_resource_limts_runnerRestartJobs https://github.com/phnmnl/galaxy.git
 WORKDIR /galaxy
 
 RUN echo "pykube==0.15.0" >> requirements.txt && \

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -47,7 +47,7 @@ if [ -n $ANSIBLE_REPO ]
        fi
 fi
 
-GALAXY_RELEASE=release_17.09_plus_isa_k8s_resource_limts
+GALAXY_RELEASE=release_17.09_isa_k8s_resource_limts_runnerRestartJobs
 GALAXY_REPO=phnmnl/galaxy
 
 GALAXY_INIT_PHENO_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG


### PR DESCRIPTION
This moves the container to a branch of Galaxy that includes our previous modifications on top of 17.09, plus recent fixes on the k8s runner for improved Galaxy-k8s jobs handling (galaxyproject/galaxy#5761).

This might fix current issues seen on Public and Publicdev, so I would appreciate a quick review. Thanks!