### PR TITLE
[WIP] Move to Galaxy 18.01

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docker-galaxy-stable"]
 	path = docker-galaxy-stable
-	url = https://github.com/pcm32/docker-galaxy-stable
+url=https://github.com/pcm32/docker-galaxy-stable
 	branch = feature/isatools_lite

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ COPY config/datatypes_conf.xml \
      config/phenomenal_tools2container.yaml\
      config/sanitize_whitelist.txt \
      config/tool_conf.xml \
+     config/dependency_resolvers_conf.xml \
   config/
 
 COPY rules/k8s_destinations.py lib/galaxy/jobs/rules/k8s_destination.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:14.04
 MAINTAINER PhenoMeNal-H2020 Project <phenomenal-h2020-users@googlegroups.com>
 
-LABEL Description="Galaxy 17.09-phenomenal for running inside Kubernetes."
+LABEL Description="Galaxy 18.01-phenomenal for running inside Kubernetes."
 LABEL software="Galaxy"
-LABEL software.version="17.09-pheno-lr"
-LABEL version="1.6"
+LABEL software.version="18.01-pheno-isa"
+LABEL version="1.7"
 LABEL description="PhenoMeNal Galaxy installation to be used inside k8s with shared file system"
 LABEL website="https://github.com/phnmnl/container-galaxy-k8s-runtime"
 LABEL documentation="https://github.com/phnmnl/phenomenal-h2020/wiki/QuickStart-Installation-for-Local-PhenoMeNal-Workflow"
@@ -33,11 +33,10 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Clone galaxy into /galaxy directory
-RUN git clone --depth 1 --single-branch --branch release_17.09_isa_k8s_resource_limts_runnerRestartJobs https://github.com/phnmnl/galaxy.git
+RUN git clone --depth 1 --single-branch --branch release_18.01_plus_isa_runnerRestartJobs https://github.com/phnmnl/galaxy.git
 WORKDIR /galaxy
 
-RUN echo "pykube==0.15.0" >> requirements.txt && \
-    echo "-e git://github.com/ISA-tools/isa-rwval.git@develop#egg=isatools" >> requirements.txt
+RUN echo "pykube==0.15.0" >> requirements.txt 
 
 RUN virtualenv .config_script_venv
 RUN /bin/bash -c "source .config_script_venv/bin/activate && \

--- a/Dockerfile_init
+++ b/Dockerfile_init
@@ -2,10 +2,10 @@ FROM pcm32/galaxy-init-pheno
 
 MAINTAINER PhenoMeNal-H2020 Project <phenomenal-h2020-users@googlegroups.com>
 
-LABEL Description="Galaxy 17.05-phenomenal for running inside Kubernetes."
+LABEL Description="Galaxy 18.01-pheno-dev for running inside Kubernetes."
 LABEL software="Galaxy Init"
-LABEL software.version="17.05-pheno-lr"
-LABEL version="1.3"
+LABEL software.version="18.01-pheno-dev"
+LABEL version="1.5"
 
 RUN wget -O ephemeris.tar https://api.github.com/repos/galaxyproject/ephemeris/tarball/eeee87a57379b8b639b06c2a50038ef449c28d73 && \
     tar -xf ephemeris.tar && rm ephemeris.tar && \

--- a/config/dependency_resolvers_conf.xml
+++ b/config/dependency_resolvers_conf.xml
@@ -1,0 +1,53 @@
+<dependency_resolvers>
+  <!-- the default configuration, first look for dependencies installed from the toolshed -->
+  <tool_shed_packages />
+  <!-- then look for env.sh files in directories according to the "galaxy packages" schema.
+       These resolvers can take a base_path attribute to specify where to look for
+       package definitions, but by default look in the directory specified by tool_dependency_dir
+       in Galaxy's config/galaxy.ini -->
+  <galaxy_packages />
+  <!-- check whether the correct version has been installed via conda -->
+  <conda auto_install="false" auto_init="false"/>
+  <!-- look for a "default" symlink pointing to a directory containing an
+       env.sh file for the package in the "galaxy packages" schema -->
+  <galaxy_packages versionless="true" />
+  <!-- look for any version of the dependency installed via conda -->
+  <conda auto_install="false" auto_init="false" versionless="true" />
+
+  <!-- LMOD dependency resolver (For the LMOD environment modules system - https://github.com/TACC/Lmod) -->
+  <!--
+  The LMOD dependency resolver attributes are:
+  * lmodexec - Path to the lmod executable on your system - Default: value of the "LMOD_CMD" environment variable
+  * settargexec - Path to the settarg executable on your system - Default: value of the "LMOD_SETTARG_CMD" environment variable
+  * modulepath - Path to the folder that contains the LMOD module files on your system - Default: value of the "MODULEPATH" environment variable
+  * versionless - Set it to true to resolve a dependency based on its name only (the version number is ignored) - Default: false
+  * mapping_files - Path to a Yaml configuration file that can be used to link tools requirements with existing LMOD modules - Default: config/lmod_modules_mapping.yml
+  Important notes:
+   - All the above attributes are optional
+   - The value of the lmodexec attribute can't just be "module" because module is actually a bash function and not the real LMOD binary (see the result of the "type module" command)
+   - The value of the modulepath attribute can also be a semicolon separated list of path
+   - In versionless mode, only modules marked as Default will be listed by the "avail" command (The -d option is used)
+   - If the config folder of your Galaxy instance contains a file called "lmod_modules_mapping.yml" (based on the lmod_modules_mapping.yml.sample file) it will be taken into consideration automatically
+  -->
+  <!--
+  <lmod />
+  <lmod versionless="true" />
+  -->
+
+  <!-- Example configuration of modules dependency resolver, uses Environment Modules -->
+  <!--
+  <modules modulecmd="/opt/Modules/3.2.9/bin/modulecmd" />
+  <modules modulecmd="/opt/Modules/3.2.9/bin/modulecmd" versionless="true" default_indicator="default" />
+  Attributes are:
+  * modulecmd - path to modulecmd
+  * versionless - default: false - whether to resolve tools using a version number or not
+  * find_by - directory or avail - use the DirectoryModuleChecker or AvailModuleChecker
+  * prefetch - default: true - in the AvailModuleChecker prefetch module info with 'module avail'
+  * default_indicator - default: '(default)' - what indicate to the AvailModuleChecker that a module is the default version
+  -->
+
+  <!-- other resolvers
+  <tool_shed_tap />
+  <homebrew />
+  -->
+</dependency_resolvers>

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -10,6 +10,7 @@
             set in universe_wsgi.ini (or equivalent general galaxy config file).  -->
       <param id="k8s_persistent_volume_claim_mount_path" from_environ="GALAXY_RUNNERS_K8S_PERSISTENT_VOLUME_CLAIM_MOUNT_PATH">/opt/galaxy_data</param>
       <param id="k8s_namespace" from_environ="GALAXY_RUNNERS_K8S_NAMESPACE">default</param>
+      <param id="k8s_galaxy_instance_id" from_environ="GALAXY_RUNNERS_K8S_GALAXY_INSTANCE_ID">?</param>
       <param id="k8s_supplemental_group_id" from_environ="GALAXY_RUNNERS_K8S_SUPPLEMENTAL_GROUP_ID">0</param>
       <param id="k8s_fs_group_id" from_environ="GALAXY_RUNNERS_K8S_FS_GROUP_ID">0</param>
       <param id="k8s_pull_policy" from_environ="GALAXY_RUNNERS_K8S_PULL_POLICY">IfNotPresent</param>

--- a/html/welcome.html
+++ b/html/welcome.html
@@ -84,7 +84,7 @@
     <div class="container">
 
         <table class="center">
-	    <tr><td class="right" colspan="2"><small>PhenoMeNal <a target="_blank" href="https://github.com/phnmnl/phenomenal-h2020/wiki/Release-notes-2018-02">release 18.02</a>,<br/>based on Galaxy <a target="_blank" href="https://docs.galaxyproject.org/en/master/releases/17.09_announce.html">version 17.09</a></small></td></tr>
+	    <tr><td class="right" colspan="2"><small>PhenoMeNal <a target="_blank" href="https://github.com/phnmnl/phenomenal-h2020/wiki/Release-notes-2018-02">release 18.02-dev</a>,<br/>based on Galaxy <a target="_blank" href="https://docs.galaxyproject.org/en/master/releases/18.01_announce.html">version 18.01</a></small></td></tr>
             <tr>
                 <td>
                     <h2>Quickstart</h2>
@@ -97,7 +97,7 @@
                         <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/Sacurine-statistical-workflow">Statistics</a>
                     </div>
 		    You can also try our <a target="_blank" href="/tours">interactive tours</a>.
-                
+
                     <h2>Support</h2>
                     <ul>
                         <li><a target="_blank" href="https://galaxyproject.org/learn/">Learn Galaxy</a> (official documentation)</li>

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -17,11 +17,12 @@ fi
     
 
 ANSIBLE_REPO=pcm32/ansible-galaxy-extras
-ANSIBLE_RELEASE=17.09-pheno-cerebellin
-GALAXY_VER_FOR_POSTGRES=17.09
+ANSIBLE_RELEASE=18.01-pheno-dev
+GALAXY_VER_FOR_POSTGRES=18.01
 POSTGRES_VERSION=`grep FROM docker-galaxy-stable/compose/galaxy-postgres/Dockerfile | awk -F":" '{ print $2 }'`
+GALAXY_BASE_FROM_TO_REPLACE=quay.io/bgruening/galaxy-base:18.01
 
-TAG=v17.09_cerebellin
+TAG=v18.01-pheno-dev
 # Uncomment to avoid using the cache when building docker images.
 #NO_CACHE="--no-cache"
 
@@ -47,7 +48,7 @@ if [ -n $ANSIBLE_REPO ]
        fi
 fi
 
-GALAXY_RELEASE=release_17.09_isa_k8s_resource_limts_runnerRestartJobs
+GALAXY_RELEASE=release_18.01_plus_isa_runnerRestartJobs
 GALAXY_REPO=phnmnl/galaxy
 
 GALAXY_INIT_PHENO_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG
@@ -58,8 +59,8 @@ if [ -n $GALAXY_REPO ]
        DOCKERFILE_INIT_1=Dockerfile
        if [ -n $ANSIBLE_REPO ]
           then
-              sed s+quay.io/bgruening/galaxy-base:dev+$GALAXY_BASE_PHENO_TAG+ docker-galaxy-stable/compose/galaxy-init/Dockerfile > docker-galaxy-stable/compose/galaxy-init/Dockerfile_init
-	      FROM=`grep ^FROM ../docker-galaxy-stable/compose/galaxy-init/Dockerfile_init | awk '{ print $2 }'`
+              sed s+$GALAXY_BASE_FROM_TO_REPLACE+$GALAXY_BASE_PHENO_TAG+ docker-galaxy-stable/compose/galaxy-init/Dockerfile > docker-galaxy-stable/compose/galaxy-init/Dockerfile_init
+	      FROM=`grep ^FROM docker-galaxy-stable/compose/galaxy-init/Dockerfile_init | awk '{ print $2 }'`
 	      echo "Using FROM $FROM for galaxy init"
 	      DOCKERFILE_INIT_1=Dockerfile_init
        fi
@@ -77,7 +78,7 @@ DOCKERFILE_INIT_FLAVOUR=Dockerfile_init
 if [ -n $GALAXY_REPO ]
 then
 	echo "Making custom galaxy-init-pheno-flavoured:$TAG starting from galaxy-init-pheno:$TAG"
-	sed s+pcm32/galaxy-init-pheno$+$GALAXY_INIT_PHENO_TAG+ Dockerfile_init > Dockerfile_init_tagged
+	sed s+pcm32/galaxy-init-pheno$+$GALAXY_INIT_PHENO_TAG+ $DOCKERFILE_INIT_FLAVOUR > Dockerfile_init_tagged
 	DOCKERFILE_INIT_FLAVOUR=Dockerfile_init_tagged
 fi
 docker build $NO_CACHE -t $GALAXY_INIT_PHENO_FLAVOURED_TAG -f $DOCKERFILE_INIT_FLAVOUR .
@@ -89,7 +90,7 @@ DOCKERFILE_WEB=Dockerfile
 if [ -n $GALAXY_REPO ]
 then
 	echo "Making custom galaxy-web-k8s:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
-	sed s+quay.io/bgruening/galaxy-base:dev+$GALAXY_BASE_PHENO_TAG+ docker-galaxy-stable/compose/galaxy-web/Dockerfile > docker-galaxy-stable/compose/galaxy-web/Dockerfile_web
+	sed s+$GALAXY_BASE_FROM_TO_REPLACE+$GALAXY_BASE_PHENO_TAG+ docker-galaxy-stable/compose/galaxy-web/Dockerfile > docker-galaxy-stable/compose/galaxy-web/Dockerfile_web
 	DOCKERFILE_WEB=Dockerfile_web
 fi
 docker build $NO_CACHE --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8,k8s -t $GALAXY_WEB_K8S_TAG -f docker-galaxy-stable/compose/galaxy-web/$DOCKERFILE_WEB docker-galaxy-stable/compose/galaxy-web/

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -14,10 +14,10 @@ then
         DOCKER_REPO=$DOCKER_REPO"/"
     fi
 fi
-    
 
-ANSIBLE_REPO=pcm32/ansible-galaxy-extras
-ANSIBLE_RELEASE=18.01-pheno-dev
+
+ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
+ANSIBLE_RELEASE=18.01-k8s
 GALAXY_VER_FOR_POSTGRES=18.01
 POSTGRES_VERSION=`grep FROM docker-galaxy-stable/compose/galaxy-postgres/Dockerfile | awk -F":" '{ print $2 }'`
 GALAXY_BASE_FROM_TO_REPLACE=quay.io/bgruening/galaxy-base:18.01


### PR DESCRIPTION
This PR moves both our galaxy container and the setup for using the community images-based setup to Galaxy 18.01, plus our ISA (datatype) and Kubernetes runner changes (better handling of jobs on instance restart). This should be tested with helm charts galaxy version >= 0.4.0 and galaxy-stable version >= 1.5.5 probably.

I would appreciate if people could test this locally and try some tools before we merge.