### PR TITLE
Fix missing tab separators in isa_cvterms

### DIFF
--- a/tool-data/isa_cvterms.loc
+++ b/tool-data/isa_cvterms.loc
@@ -422,16 +422,16 @@
 399	Benjamini and Yekutieli false discovery rate correction method (OBI:0200049)	statistics
 400	Holm-Bonferroni family-wise error rate correction method (OBI:0200066)	statistics
 401	Holm false discovery rate correction (STATO:000541)	statistics
-402 Hommel false discovery rate correction (STATO:000542)	statistics
-403 Student's t-test (OBI:0000739)	statistics
-404 Wilcoxon rank sum test (STATO:0000076)	statistics
-405 Kruskal-Wallis test (STATO:0000094)	statistics
-406 Pearson's correlation coefficient (STATO:0000280)	statistics
-407 Spearman's correlation coefficient (STATO:0000201)	statistics
-408 Pareto scaling (OBI:0200037)	statistics
+402	Hommel false discovery rate correction (STATO:000542)	statistics
+403	Student's t-test (OBI:0000739)	statistics
+404	Wilcoxon rank sum test (STATO:0000076)	statistics
+405	Kruskal-Wallis test (STATO:0000094)	statistics
+406	Pearson's correlation coefficient (STATO:0000280)	statistics
+407	Spearman's correlation coefficient (STATO:0000201)	statistics
+408	Pareto scaling (OBI:0200037)	statistics
 409	mean centering (OBI:0200029)	statistics
-410 unit-variance scaling (OBI:0200149)	statistics
-411 logarithmic transformation (OBI:0200094)	statistics
+410	unit-variance scaling (OBI:0200149)	statistics
+411	logarithmic transformation (OBI:0200094)	statistics
 412	PCA by singular value decomposition (OBI:0200051)	statistics
 413	PLS by nonlinear iterative partial least squares (OBI:0200107)	statistics
 414	OPLS by nonlinear iterative partial least squares ()	statistics


### PR DESCRIPTION
I found galaxy complaining about some of the entries in the `isa_cvterms` table:

```
galaxy.tools.data WARNING 2018-06-20 17:40:14,696 Line 425 in tool data table 'isa_cvterms' is invalid (HINT: '<TAB>' characters must be used to separate fields):
402 Hommel false discovery rate correction (STATO:000542)       statistics
galaxy.tools.data WARNING 2018-06-20 17:40:14,696 Line 426 in tool data table 'isa_cvterms' is invalid (HINT: '<TAB>' characters must be used to separate fields):
403 Student's t-test (OBI:0000739)      statistics
galaxy.tools.data WARNING 2018-06-20 17:40:14,696 Line 427 in tool data table 'isa_cvterms' is invalid (HINT: '<TAB>' characters must be used to separate fields):
404 Wilcoxon rank sum test (STATO:0000076)      statistics
galaxy.tools.data WARNING 2018-06-20 17:40:14,696 Line 428 in tool data table 'isa_cvterms' is invalid (HINT: '<TAB>' characters must be used to separate fields):
405 Kruskal-Wallis test (STATO:0000094) statistics
galaxy.tools.data WARNING 2018-06-20 17:40:14,696 Line 429 in tool data table 'isa_cvterms' is invalid (HINT: '<TAB>' characters must be used to separate fields):
406 Pearson's correlation coefficient (STATO:0000280)   statistics
galaxy.tools.data WARNING 2018-06-20 17:40:14,696 Line 430 in tool data table 'isa_cvterms' is invalid (HINT: '<TAB>' characters must be used to separate fields):
407 Spearman's correlation coefficient (STATO:0000201)  statistics
galaxy.tools.data WARNING 2018-06-20 17:40:14,696 Line 431 in tool data table 'isa_cvterms' is invalid (HINT: '<TAB>' characters must be used to separate fields):
408 Pareto scaling (OBI:0200037)        statistics
galaxy.tools.data WARNING 2018-06-20 17:40:14,696 Line 433 in tool data table 'isa_cvterms' is invalid (HINT: '<TAB>' characters must be used to separate fields):
410 unit-variance scaling (OBI:0200149) statistics
galaxy.tools.data WARNING 2018-06-20 17:40:14,697 Line 434 in tool data table 'isa_cvterms' is invalid (HINT: '<TAB>' characters must be used to separate fields):
411 logarithmic transformation (OBI:0200094)    statistics
galaxy.tools.data DEBUG 2018-06-20 17:40:14,697 Loaded 408 lines from 'tool-data/isa_cvterms.loc' for 'isa_cvterms'
galaxy.tools.data DEBUG 2018-06-20 17:40:14,697 Loaded tool data table 'isa_cvterms' from file './config/tool_data_table_conf.xml'
```

This commit changes those spaces to tabs and so should fix the problem.