### PR TITLE
Fix reference to undefined `text` data format in Fido

### DIFF
--- a/tools/phenomenal/ms/OpenMS/DTAExtractor.xml
+++ b/tools/phenomenal/ms/OpenMS/DTAExtractor.xml
@@ -113,7 +113,7 @@
     </expand>
   </inputs>
   <outputs>
-    <data name="param_stdout" format="text" label="Output from stdout"/>
+    <data name="param_stdout" format="txt" label="Output from stdout"/>
   </outputs>
   <help>Extracts spectra of an MS run file to several files in DTA format.
 

--- a/tools/phenomenal/ms/OpenMS/DTAExtractor.xml
+++ b/tools/phenomenal/ms/OpenMS/DTAExtractor.xml
@@ -113,7 +113,7 @@
     </expand>
   </inputs>
   <outputs>
-    <data name="param_stdout" format="txt" label="Output from stdout"/>
+    <data name="param_stdout" type="data" format="txt" label="Output from stdout"/>
   </outputs>
   <help>Extracts spectra of an MS run file to several files in DTA format.
 

--- a/tools/phenomenal/ms/OpenMS/FidoAdapter.xml
+++ b/tools/phenomenal/ms/OpenMS/FidoAdapter.xml
@@ -93,8 +93,8 @@
 ]]></command>
   <inputs>
     <param name="param_in" type="data" format="idxml" optional="False" label="Input: identification results" help="(-in) "/>
-    <param name="param_fido_executable" type="data" format="text" value="Fido" label="Path to the Fido executable to use; may be empty if the executable is globally available" help="(-fido_executable) "/>
-    <param name="param_fidocp_executable" type="data" format="text" value="FidoChooseParameters" label="Path to the FidoChooseParameters executable to use; may be empty if the executable is globally available" help="(-fidocp_executable) "/>
+    <param name="param_fido_executable" type="data" format="txt" value="Fido" label="Path to the Fido executable to use; may be empty if the executable is globally available" help="(-fido_executable) "/>
+    <param name="param_fidocp_executable" type="data" format="txt" value="FidoChooseParameters" label="Path to the FidoChooseParameters executable to use; may be empty if the executable is globally available" help="(-fidocp_executable) "/>
     <param name="param_separate_runs" display="radio" type="boolean" truevalue="-separate_runs" falsevalue="" checked="false" optional="True" label="Process multiple protein identification runs in the input separately, don't merge them" help="(-separate_runs) Merging results in loss of descriptive information of the single protein identification runs"/>
     <param name="param_greedy_group_resolution" display="radio" type="boolean" truevalue="-greedy_group_resolution" falsevalue="" checked="false" optional="True" label="Post-process Fido output with greedy resolution of shared peptides based on the protein probabilities" help="(-greedy_group_resolution) Also adds the resolved ambiguity groups to output"/>
     <param name="param_no_cleanup" display="radio" type="boolean" truevalue="-no_cleanup" falsevalue="" checked="false" optional="True" label="Omit clean-up of peptide sequences (removal of non-letter characters, replacement of I with L)" help="(-no_cleanup) "/>

--- a/tools/phenomenal/ms/OpenMS/InspectAdapter.xml
+++ b/tools/phenomenal/ms/OpenMS/InspectAdapter.xml
@@ -216,7 +216,7 @@
         </valid>
       </sanitizer>
     </param>
-    <param name="param_inspect_input" type="data" format="text" label="name for the input file of Inspect (may only be used in a full run)" help="(-inspect_input) "/>
+    <param name="param_inspect_input" type="data" format="txt" label="name for the input file of Inspect (may only be used in a full run)" help="(-inspect_input) "/>
     <param name="param_multicharge" display="radio" type="boolean" truevalue="-multicharge" falsevalue="" checked="false" optional="True" label="attempt to guess the precursor charge and mass, &lt;br&gt;and consider multiple charge states if feasible" help="(-multicharge) "/>
     <param name="param_max_modifications_pp" type="integer" value="-1" label="number of PTMs permitted in a single peptide" help="(-max_modifications_pp) "/>
     <param name="param_tag_count" type="integer" value="-1" label="number of tags to generate" help="(-tag_count) "/>

--- a/tools/phenomenal/ms/OpenMS/LuciphorAdapter.xml
+++ b/tools/phenomenal/ms/OpenMS/LuciphorAdapter.xml
@@ -128,7 +128,7 @@
   <inputs>
     <param name="param_in" type="data" format="mzml" optional="False" label="Input spectrum file" help="(-in) "/>
     <param name="param_id" type="data" format="idxml" optional="False" label="Protein/peptide identifications file" help="(-id) "/>
-    <param name="param_executable" type="data" format="text" value="luciphor2.jar" label="LuciPHOr2 .jar file," help="(-executable) e.g. 'c:\program files\luciphor2.jar'"/>
+    <param name="param_executable" type="data" format="txt" value="luciphor2.jar" label="LuciPHOr2 .jar file," help="(-executable) e.g. 'c:\program files\luciphor2.jar'"/>
     <param name="param_fragment_method" display="radio" type="select" optional="False" value="CID" label="Fragmentation method" help="(-fragment_method) ">
       <option value="CID" selected="true">CID</option>
       <option value="HCD">HCD</option>
@@ -1771,7 +1771,7 @@
       <option value="0" selected="true">0</option>
       <option value="1">1</option>
     </param>
-    <param name="param_java_executable" type="data" format="text" value="java" label="The Java executable" help="(-java_executable) Usually Java is on the system PATH. If Java is not found, use this parameter to specify the full path to Java"/>
+    <param name="param_java_executable" type="data" format="txt" value="java" label="The Java executable" help="(-java_executable) Usually Java is on the system PATH. If Java is not found, use this parameter to specify the full path to Java"/>
     <param name="param_threads" type="integer" value="1" label="Sets the number of threads allowed to be used by the TOPP tool" help="(-threads) "/>
     <expand macro="advanced_options">
       <param name="param_version" type="text" size="30" value="2.1.0" label="Version of the tool that generated this parameters file" help="(-version) ">

--- a/tools/phenomenal/ms/OpenMS/MSGFPlusAdapter.xml
+++ b/tools/phenomenal/ms/OpenMS/MSGFPlusAdapter.xml
@@ -137,7 +137,7 @@
 ]]></command>
   <inputs>
     <param name="param_in" type="data" format="mzml" optional="False" label="Input file (MS-GF+ parameter '-s')" help="(-in) "/>
-    <param name="param_executable" type="data" format="text" value="MSGFPlus.jar" label="MS-GF+ .jar file," help="(-executable) e.g. 'c:\program files\MSGFPlus.jar'"/>
+    <param name="param_executable" type="data" format="txt" value="MSGFPlus.jar" label="MS-GF+ .jar file," help="(-executable) e.g. 'c:\program files\MSGFPlus.jar'"/>
     <param name="param_database" type="data" format="fasta" optional="False" label="Protein sequence database (FASTA file; MS-GF+ parameter '-d')" help="(-database) Non-existing relative filenames are looked up via 'OpenMS.ini:id_db_dir'"/>
     <param name="param_add_decoys" display="radio" type="boolean" truevalue="-add_decoys" falsevalue="" checked="false" optional="True" label="Create decoy proteins (reversed sequences) and append them to the database for the search (MS-GF+ parameter '-tda')" help="(-add_decoys) This allows the calculation of FDRs, but should only be used if the database does not already contain decoys"/>
     <param name="param_precursor_mass_tolerance" type="float" value="20.0" label="Precursor monoisotopic mass tolerance (MS-GF+ parameter '-t')" help="(-precursor_mass_tolerance) "/>
@@ -3396,7 +3396,7 @@
         <option value="trifluoro (L)">trifluoro (L)</option>
       </param>
     </repeat>
-    <param name="param_java_executable" type="data" format="text" value="java" label="The Java executable" help="(-java_executable) Usually Java is on the system PATH. If Java is not found, use this parameter to specify the full path to Java"/>
+    <param name="param_java_executable" type="data" format="txt" value="java" label="The Java executable" help="(-java_executable) Usually Java is on the system PATH. If Java is not found, use this parameter to specify the full path to Java"/>
     <param name="param_java_memory" type="integer" value="3500" label="Maximum Java heap size (in MB)" help="(-java_memory) "/>
     <param name="param_threads" type="integer" value="1" label="Sets the number of threads allowed to be used by the TOPP tool" help="(-threads) "/>
     <expand macro="advanced_options">

--- a/tools/phenomenal/ms/OpenMS/MascotAdapter.xml
+++ b/tools/phenomenal/ms/OpenMS/MascotAdapter.xml
@@ -147,7 +147,7 @@
 #end if
 ]]></command>
   <inputs>
-    <param name="param_in" type="data" format="text" label="input file in mzData format" help="(-in) &lt;br&gt;Note: In mode 'mascot_out' a Mascot results file (.mascotXML) is read"/>
+    <param name="param_in" type="data" format="txt" label="input file in mzData format" help="(-in) &lt;br&gt;Note: In mode 'mascot_out' a Mascot results file (.mascotXML) is read"/>
     <param name="param_mascot_in" display="radio" type="boolean" truevalue="-mascot_in" falsevalue="" checked="false" optional="True" label="if this flag is set the MascotAdapter will read in mzData and write Mascot generic format" help="(-mascot_in) "/>
     <param name="param_mascot_out" display="radio" type="boolean" truevalue="-mascot_out" falsevalue="" checked="false" optional="True" label="if this flag is set the MascotAdapter will read in a Mascot results file (.mascotXML) and write idXML" help="(-mascot_out) "/>
     <param name="param_instrument" type="text" size="30" value="Default" label="the instrument that was used to measure the spectra" help="(-instrument) ">

--- a/tools/phenomenal/ms/OpenMS/MyriMatchAdapter.xml
+++ b/tools/phenomenal/ms/OpenMS/MyriMatchAdapter.xml
@@ -3365,7 +3365,7 @@
         <option value="trifluoro (L)">trifluoro (L)</option>
       </param>
     </repeat>
-    <param name="param_myrimatch_executable" type="data" format="text" value="myrimatch" label="The 'myrimatch' executable of the MyriMatch installation" help="(-myrimatch_executable) "/>
+    <param name="param_myrimatch_executable" type="data" format="txt" value="myrimatch" label="The 'myrimatch' executable of the MyriMatch installation" help="(-myrimatch_executable) "/>
     <param name="param_NumChargeStates" type="integer" value="3" label="The number of charge states that MyriMatch will handle during all stages of the program" help="(-NumChargeStates) "/>
     <param name="param_TicCutoffPercentage" type="float" value="0.98" label="Noise peaks are filtered out by sorting the original peaks in descending order of intensity, and then picking peaks from that list until the cumulative ion current of the picked peaks divided by the total ion current (TIC) is greater than or equal to this paramete" help="(-TicCutoffPercentage) "/>
     <param name="param_MaxDynamicMods" type="integer" value="2" label="This parameter sets the maximum number of modified residues that may be in any candidate sequence" help="(-MaxDynamicMods) "/>

--- a/tools/phenomenal/ms/OpenMS/OMSSAAdapter.xml
+++ b/tools/phenomenal/ms/OpenMS/OMSSAAdapter.xml
@@ -3385,7 +3385,7 @@
         <option value="trifluoro (L)">trifluoro (L)</option>
       </param>
     </repeat>
-    <param name="param_omssa_executable" type="data" format="text" value="omssacl" label="The 'omssacl' executable of the OMSSA installation" help="(-omssa_executable) "/>
+    <param name="param_omssa_executable" type="data" format="txt" value="omssacl" label="The 'omssacl' executable of the OMSSA installation" help="(-omssa_executable) "/>
     <param name="param_v" type="integer" value="1" label="number of missed cleavages allowed" help="(-v) "/>
     <param name="param_enzyme" type="select" optional="False" value="Trypsin" label="The enzyme used for peptide digestion" help="(-enzyme) ">
       <option value="Trypsin" selected="true">Trypsin</option>

--- a/tools/phenomenal/ms/OpenMS/PepNovoAdapter.xml
+++ b/tools/phenomenal/ms/OpenMS/PepNovoAdapter.xml
@@ -104,7 +104,7 @@
 ]]></command>
   <inputs>
     <param name="param_in" type="data" format="mzml" optional="False" label="input file" help="(-in) "/>
-    <param name="param_pepnovo_executable" type="data" format="text" label="The &quot;PepNovo&quot; executable of the PepNovo installation" help="(-pepnovo_executable) "/>
+    <param name="param_pepnovo_executable" type="data" format="txt" label="The &quot;PepNovo&quot; executable of the PepNovo installation" help="(-pepnovo_executable) "/>
     <param name="param_model_directory" type="text" size="30" label="Name of the directory where the model files are kept" help="(-model_directory) ">
       <sanitizer>
         <valid initial="string.printable">

--- a/tools/phenomenal/ms/OpenMS/XTandemAdapter.xml
+++ b/tools/phenomenal/ms/OpenMS/XTandemAdapter.xml
@@ -126,7 +126,7 @@
   <inputs>
     <param name="param_in" type="data" format="mzml" optional="False" label="Input file" help="(-in) "/>
     <param name="param_database" type="data" format="fasta" optional="False" label="FASTA file or pro file" help="(-database) Non-existing relative file-names are looked up via'OpenMS.ini:id_db_dir'"/>
-    <param name="param_xtandem_executable" type="data" format="text" value="tandem.exe" label="X! Tandem executable of the installation" help="(-xtandem_executable) e.g. 'tandem.exe'"/>
+    <param name="param_xtandem_executable" type="data" format="txt" value="tandem.exe" label="X! Tandem executable of the installation" help="(-xtandem_executable) e.g. 'tandem.exe'"/>
     <param name="param_default_config_file" type="data" format="mzml" optional="True" value="CHEMISTRY/XTandem_default_input.xml" label="Default parameters input file, defaulting to the ones in the OpenMS/share folder.All parameters of this adapter take precedence over this file! Use it for parameters not available here!" help="(-default_config_file) "/>
     <param name="param_ignore_adapter_param" display="radio" type="boolean" truevalue="-ignore_adapter_param" falsevalue="" checked="false" optional="True" label="The config given in 'default_config_file' is used exclusively! No matter what other parameters (apart from -in,-out,-database,-xtandem_executable) are saying" help="(-ignore_adapter_param) "/>
     <param name="param_precursor_mass_tolerance" type="float" value="10.0" label="Precursor mass tolerance" help="(-precursor_mass_tolerance) "/>


### PR DESCRIPTION
The fido wrappers were referencing `text` instead of `txt`.