### PR TITLE
New nmr-integrals tool for NMR spectrum comparison

### DIFF
--- a/config/datatypes_conf.xml
+++ b/config/datatypes_conf.xml
@@ -653,7 +653,6 @@
     <datatype extension="rdata.xcms.group" type="galaxy.datatypes.rdata_xcms_datatype:RdataXcmsGroup" mimetype="application/x-gzip" subclass="true" display_in_upload="true" />
     <datatype extension="rdata.xcms.raw" type="galaxy.datatypes.rdata_xcms_datatype:RdataXcmsRaw" mimetype="application/x-gzip" subclass="true" display_in_upload="true" />
     <datatype extension="rdata.xcms.retcor" type="galaxy.datatypes.rdata_xcms_datatype:RdataXcmsRetcor" mimetype="application/x-gzip" subclass="true" display_in_upload="true" />
-    <datatype extension="bruker_zip" type="galaxy.datatypes.binary:CompressedZipArchive" subclass="true" display_in_upload="true"/>
   </registration>
   <sniffers>
     <!--

--- a/config/datatypes_conf.xml
+++ b/config/datatypes_conf.xml
@@ -653,6 +653,7 @@
     <datatype extension="rdata.xcms.group" type="galaxy.datatypes.rdata_xcms_datatype:RdataXcmsGroup" mimetype="application/x-gzip" subclass="true" display_in_upload="true" />
     <datatype extension="rdata.xcms.raw" type="galaxy.datatypes.rdata_xcms_datatype:RdataXcmsRaw" mimetype="application/x-gzip" subclass="true" display_in_upload="true" />
     <datatype extension="rdata.xcms.retcor" type="galaxy.datatypes.rdata_xcms_datatype:RdataXcmsRetcor" mimetype="application/x-gzip" subclass="true" display_in_upload="true" />
+    <datatype extension="bruker_zip" type="galaxy.datatypes.binary:CompressedZipArchive" subclass="true" display_in_upload="true"/>
   </registration>
   <sniffers>
     <!--

--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -240,6 +240,7 @@
     <tool id="rnmr1d" destination="dynamic-k8s-xlarge" resources="all"/>
     <tool id="rnmr1d-stacked-plot" destination="dynamic-k8s-tiny" resources="all"/>
     <tool id="rnmr1d-prepare-output" destination="dynamic-k8s-small" resources="all"/>
+    <tool id="nmr-integrals" destination="dynamic-k8s-tiny" resources="all"/>
     <!-- old NMR -->
     <!-- <tool id="mtbls2nmrglue" destination="nmrglue-container"/> -->
     <tool id="soap_process" destination="soap-nmr-container"/>

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -302,6 +302,13 @@ assignment:
   - rnmr1d
   - rnmr1d-stacked-plot
   - rnmr1d-prepare-output
+- docker_image_override: nmr-integrals
+  docker_owner_override: phnmnl
+  docker_repo_override: container-registry.phenomenal-h2020.eu
+  docker_tag_override: latest
+  max_pod_retrials: 3
+  tools_id:
+  - nmr-integrals
 - docker_image_override: metabomatching
   docker_owner_override: phnmnl
   docker_repo_override: container-registry.phenomenal-h2020.eu

--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -133,7 +133,7 @@
       <!-- <tool file="phenomenal/nmr/mtbls2nmrglue.xml"/> -->
       <tool file="phenomenal/nmr/soap_process.xml"/>
       <tool file="phenomenal/nmr/soap_opls.xml"/>
-			<tool file="phenomenal/nmr/nmr-integrals.xml"/>
+      <tool file="phenomenal/nmr/nmr-integrals.xml"/>
    </section>
 
   <label id="phenomenal-ms" text="MS Data Analysis Tools" /> 

--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -133,6 +133,7 @@
       <!-- <tool file="phenomenal/nmr/mtbls2nmrglue.xml"/> -->
       <tool file="phenomenal/nmr/soap_process.xml"/>
       <tool file="phenomenal/nmr/soap_opls.xml"/>
+			<tool file="phenomenal/nmr/nmr-integrals.xml"/>
    </section>
 
   <label id="phenomenal-ms" text="MS Data Analysis Tools" /> 

--- a/tools/phenomenal/nmr/nmr-integrals.xml
+++ b/tools/phenomenal/nmr/nmr-integrals.xml
@@ -1,25 +1,18 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<tool id="nmr_integrals" name="Compare Bruker NMR/metabolites " version="1.0">
+<tool id="nmr-integrals" name="Compare Bruker NMR/metabolites " version="1.0">
   <description>Compare specific metabolite levels in two NMR spectra</description>
   <command detect_errors="exit_code"><![CDATA[
-		ReferenceDir="${PWD}/input/reference"
-		TestDir="${PWD}/input/test"
-		mkdir --parents "${ReferenceDir}" "${TestDir}"
-		echo "Unzipping input archives" >&2
-		unzip -q -d "${ReferenceDir}" "${reference_spec}
-		unzip -q -d "${TestDir}" "${test_spec}
-		echo "Analyzing" >&2
-		integrals.R --left=${left} --right=${right} --where=${where} --plotfile "${output_plotfile}" "${signal_metabolites}" "${ReferenceDir}" "${TestDir}" > "${output_table}"
+    integrals_galaxy_wrapper.sh "\${PWD}" ${left} ${right} ${where} "${output_plotfile}" "${signal_metabolites}" "${reference_spec}" "${test_spec}" "${output_table}"
   ]]>
   </command>
   <inputs>
-    <param name="left" type="float" value="0" label="Left" help="Left"/>
-    <param name="right" type="float" value="0" label="Right" help="Right"/>
-    <param name="where" type="float" value="0" label="Where" help="Where"/>
+    <param name="left" type="float" value="0" label="Left" help="Left (e.g., 5.225)"/>
+    <param name="right" type="float" value="0" label="Right" help="Right (e.g., 5.257)"/>
+    <param name="where" type="float" value="0" label="Where" help="Where (e.g., 5.243)"/>
     <param name="signal_metabolites" type="data" format="tsv" label="Signal Metabolites" help="Table of the metabolites to be used to compare the two spectra."/>
-    <param name="reference_spec" type="data" format="zip" label="Reference" help="Reference spectrum (zipped Bruker NMR dataset)"/>
-    <param name="test_spec" type="data" format="zip" label="Test" help="Test spectrum (zipped Bruker NMR dataset)"/>
+    <param name="reference_spec" type="data" format="bruker_zip" label="Reference" help="Reference spectrum (zipped Bruker NMR dataset)"/>
+    <param name="test_spec" type="data" format="bruker_zip" label="Test" help="Test spectrum (zipped Bruker NMR dataset)"/>
   </inputs>
   <outputs>
     <data format="pdf" name="output_plotfile" label="Metabolite plots" />

--- a/tools/phenomenal/nmr/nmr-integrals.xml
+++ b/tools/phenomenal/nmr/nmr-integrals.xml
@@ -3,16 +3,21 @@
 <tool id="nmr-integrals" name="Compare Bruker NMR/metabolites " version="1.0">
   <description>Compare specific metabolite levels in two NMR spectra</description>
   <command detect_errors="exit_code"><![CDATA[
-    integrals_galaxy_wrapper.sh "\${PWD}" ${left} ${right} ${where} "${output_plotfile}" "${signal_metabolites}" "${reference_spec}" "${test_spec}" "${output_table}"
-  ]]>
+    #if $signal_metabolites:
+      integrals_galaxy_wrapper.sh "\${PWD}" ${left} ${right} ${where} "${output_plotfile}" "${reference_spec}" "${test_spec}" "${output_table}" "${signal_metabolites}"
+    #else
+      integrals_galaxy_wrapper.sh "\${PWD}" ${left} ${right} ${where} "${output_plotfile}" "${reference_spec}" "${test_spec}" "${output_table}"
+    #end if
+    ]]>
   </command>
   <inputs>
-    <param name="left" type="float" value="0" label="Left" help="Left (e.g., 5.257)"/>
-    <param name="right" type="float" value="0" label="Right" help="Right (e.g., 5.225)"/>
-    <param name="where" type="float" value="0" label="Where" help="Where (e.g., 5.243)"/>
-    <param name="signal_metabolites" type="data" format="tsv" label="Signal Metabolites" help="Table of the metabolites to be used to compare the two spectra."/>
+    <param name="left" type="float" value="5.257" label="Left" help="Left (e.g., 5.257)"/>
+    <param name="right" type="float" value="5.225" label="Right" help="Right (e.g., 5.225)"/>
+    <param name="where" type="float" value="5.243" label="Where" help="Where (e.g., 5.243)"/>
     <param name="reference_spec" type="data" format="no_unzip.zip" label="Reference" help="Reference spectrum (zipped Bruker NMR dataset)"/>
     <param name="test_spec" type="data" format="no_unzip.zip" label="Test" help="Test spectrum (zipped Bruker NMR dataset)"/>
+    <param name="signal_metabolites" type="data" format="tsv" label="Signal Metabolites" optional="true"
+        help="Table of signal metabolites to be used to compare the two spectra (optional)."/>
   </inputs>
   <outputs>
     <data format="pdf" name="output_plotfile" label="Metabolite plots" />
@@ -32,20 +37,138 @@ NMR-integrals
 Short Description
 ---------------------
 
-Compares specific metabolite levels in two NMR spectra.
+Compares specific metabolite levels in two NMR spectra of blood serum/plasma samples.
 
 ---------------
 Description
 ---------------
 
 This tool implements a comparison between the NMR spectra of a reference sample
-and a test sample, based on selected metabolite signals.  The operation is part
-of the QC procedure implemented in a number of biobanks, where samples are
-periodically analyzed to detected and measure long-term quality decay.
+and a test sample, based on selected metabolite signals.
 
+Two aliquots of the same sample have the same metabolomic profiles, and thus
+have exactly the same NMR spectra. Based on this premise, the NMR spectrum can
+be used to check the quality of samples. This tool compares the NMR
+spectrum a blood serum/plasma sample with the NMR spectrum of a different
+aliquot of the same sample acquired at a different time (e.g., spectrum
+acquired at the moment of the sample collection vs. spectrum acquired after
+long-term storage).  The metabolites tested are those one that were
+experimentally identified as "sensible" indicators of sample quality. The
+respective NMR signals are selected, and their relative concentrations inside
+each of the sample compared are measured. Spectral total area is also calculated
+to have information about the presence of contaminations.
+
+The operation is part of a QC procedure for biobanks, where samples are
+periodically analyzed to detected and measure long-term quality decay.
 
 The tool generates a table and a set of plots indicating the signal differences
 and whether they are significant.
+
+
+-------
+Input
+-------
+
+
+Left
+  Left margin of the integration range (ppm value)
+
+Right
+  Right margin of the integration range (ppm value) (must be greater than left)
+
+Where
+  ppm value (inside the integration rage) where we want to align the signals of the two spectra.
+
+Reference spectrum
+  Bruker monodimensional 1H cpmg NMR spectrum
+
+Test spectrum
+  Bruker monodimensional 1H cpmg NMR spectrum
+
+Signal Metabolites
+  Optional table of signal metabolites, to override default behaviour.
+
+
++++++++++++++++++++
+Metabolites table
++++++++++++++++++++
+
+The metabolites table specifies, for each selected metabolite, an integration
+window for one or more of its signals inside the spectra.  The program will by
+default use a table (shown below) made specifically for the purpose of detecting
+decay of blood serum/plasma samples.  You may however customize this table to
+apply the technique to other types of samples.
+
+
+Here is the table format.
+
+Columns:
+
+1st column
+  Metabolite name
+
+2nd column
+  Right margin of the integration range (ppm value)
+
+3rd column
+  Left margin of the integration range (ppm value)
+
+4th column
+  ppm value (inside the integration rage) where we want to align the signals of the two spectra.
+
+5th column
+  base line correction (0: no /1: yes)
+
+6th column
+  signal alignment at where (0: no /1: yes)
+
+
+
+The table below is the *default table*, which has been verified to return sensible
+values:
+
++-------------+-----------+----------+-----------+-------------------------+------------------+
+| Metabolite  | right ppm | left ppm | ppm align | baseline correct on/off | alignment on/off |
++=============+===========+==========+===========+=========================+==================+
+| totalarea   |   1.3000  |0.9000    | 1.2797    |            0            |        1         |
+| totalarea1  |   4.2     |1.3000    | 1.3246    |            0            |        1         |
+| totalarea2  |   9.0     |5.00      | 5.2431    |            0            |        1         |
+| glucose     |   5.2500  |5.2200    | 5.2367    |            1            |        1         |
+| lactate     |   4.1137  |4.0920    | 4.1085    |            1            |        1         |
+| citrate     |   2.5600  |2.5400    | 2.55      |            1            |        1         |
+| pyruvate    |   2.3780  |2.3650    | 2.373     |            1            |        1         |
+| ethanol     |   1.2028  |1.1926    | 1.1969    |            0            |        0         |
+| ethanol1    |   1.1913  |1.1798    | 1.1885    |            0            |        0         |
+| glycine     |   3.5700  |3.5583    | 3.563     |            1            |        1         |
+| acetate     |   1.9231  |1.9165    | 1.9189    |            1            |        1         |
+| lypids      |   1.3150  |1.2500    | 1.278     |            1            |        1         |
+| glycerol    |   3.6959  |3.6368    | 3.6674    |            0            |        0         |
++-------------+-----------+----------+-----------+-------------------------+------------------+
+
+--------
+Output
+--------
+
+1. Plots of ppm vs relative intensity, for each metabolite (PDF format).
+2. Table (tab-separated columns) with the difference in the relative
+concentration of the selected metabolites. Threshold: +/-20%.
+
+
+
+Table columns:
+
+1st column
+  Metabolite name
+
+2nd column
+  ok/bad
+
+4th column
+  relative concetration difference (percentage)
+
+
+The 3rd column is always "diff" and the 5th one is always a "%" sign.
+
   </help>
 
 </tool>

--- a/tools/phenomenal/nmr/nmr-integrals.xml
+++ b/tools/phenomenal/nmr/nmr-integrals.xml
@@ -1,0 +1,51 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<tool id="nmr_integrals" name="Compare Bruker NMR/metabolites " version="1.0">
+  <description>Compare specific metabolite levels in two NMR spectra</description>
+  <command detect_errors="exit_code"><![CDATA[
+		ReferenceDir="${PWD}/input/reference"
+		TestDir="${PWD}/input/test"
+		mkdir --parents "${ReferenceDir}" "${TestDir}"
+		echo "Unzipping input archives" >&2
+		unzip -q -d "${ReferenceDir}" "${reference_spec}
+		unzip -q -d "${TestDir}" "${test_spec}
+		echo "Analyzing" >&2
+		integrals.R --left=${left} --right=${right} --where=${where} --plotfile "${output_plotfile}" "${signal_metabolites}" "${ReferenceDir}" "${TestDir}" > "${output_table}"
+  ]]>
+  </command>
+  <inputs>
+    <param name="left" type="float" value="0" label="Left" help="Left"/>
+    <param name="right" type="float" value="0" label="Right" help="Right"/>
+    <param name="where" type="float" value="0" label="Where" help="Where"/>
+    <param name="signal_metabolites" type="data" format="tsv" label="Signal Metabolites" help="Table of the metabolites to be used to compare the two spectra."/>
+    <param name="reference_spec" type="data" format="zip" label="Reference" help="Reference spectrum (zipped Bruker NMR dataset)"/>
+    <param name="test_spec" type="data" format="zip" label="Test" help="Test spectrum (zipped Bruker NMR dataset)"/>
+  </inputs>
+  <outputs>
+    <data format="pdf" name="output_plotfile" label="Metabolite plots" />
+    <data format="tsv" name="output_table" label="Comparison table" />
+  </outputs>
+  <stdio>
+    <exit_code range="1:" level="fatal"/>
+  </stdio>
+
+  <help>
+## Short Description
+
+Compares specific metabolite levels in two NMR spectra.
+
+
+## Description
+
+This tool implements a comparison between the NMR spectra of a reference sample
+and a test sample, based on selected metabolite signals.  The operation is part
+of the QC procedure implemented in a number of biobanks, where samples are
+periodically analyzed to detected and measure long-term quality decay.
+
+
+The tool generates a table and a set of plots indicating the signal differences
+and whether they are significant.
+```
+  </help>
+
+</tool>

--- a/tools/phenomenal/nmr/nmr-integrals.xml
+++ b/tools/phenomenal/nmr/nmr-integrals.xml
@@ -23,12 +23,20 @@
   </stdio>
 
   <help>
-## Short Description
+
+===================
+NMR-integrals
+===================
+
+---------------------
+Short Description
+---------------------
 
 Compares specific metabolite levels in two NMR spectra.
 
-
-## Description
+---------------
+Description
+---------------
 
 This tool implements a comparison between the NMR spectra of a reference sample
 and a test sample, based on selected metabolite signals.  The operation is part
@@ -38,7 +46,6 @@ periodically analyzed to detected and measure long-term quality decay.
 
 The tool generates a table and a set of plots indicating the signal differences
 and whether they are significant.
-```
   </help>
 
 </tool>

--- a/tools/phenomenal/nmr/nmr-integrals.xml
+++ b/tools/phenomenal/nmr/nmr-integrals.xml
@@ -11,8 +11,8 @@
     <param name="right" type="float" value="0" label="Right" help="Right (e.g., 5.257)"/>
     <param name="where" type="float" value="0" label="Where" help="Where (e.g., 5.243)"/>
     <param name="signal_metabolites" type="data" format="tsv" label="Signal Metabolites" help="Table of the metabolites to be used to compare the two spectra."/>
-    <param name="reference_spec" type="data" format="bruker_zip" label="Reference" help="Reference spectrum (zipped Bruker NMR dataset)"/>
-    <param name="test_spec" type="data" format="bruker_zip" label="Test" help="Test spectrum (zipped Bruker NMR dataset)"/>
+    <param name="reference_spec" type="data" format="no_unzip.zip" label="Reference" help="Reference spectrum (zipped Bruker NMR dataset)"/>
+    <param name="test_spec" type="data" format="no_unzip.zip" label="Test" help="Test spectrum (zipped Bruker NMR dataset)"/>
   </inputs>
   <outputs>
     <data format="pdf" name="output_plotfile" label="Metabolite plots" />

--- a/tools/phenomenal/nmr/nmr-integrals.xml
+++ b/tools/phenomenal/nmr/nmr-integrals.xml
@@ -7,8 +7,8 @@
   ]]>
   </command>
   <inputs>
-    <param name="left" type="float" value="0" label="Left" help="Left (e.g., 5.225)"/>
-    <param name="right" type="float" value="0" label="Right" help="Right (e.g., 5.257)"/>
+    <param name="left" type="float" value="0" label="Left" help="Left (e.g., 5.257)"/>
+    <param name="right" type="float" value="0" label="Right" help="Right (e.g., 5.225)"/>
     <param name="where" type="float" value="0" label="Where" help="Where (e.g., 5.243)"/>
     <param name="signal_metabolites" type="data" format="tsv" label="Signal Metabolites" help="Table of the metabolites to be used to compare the two spectra."/>
     <param name="reference_spec" type="data" format="no_unzip.zip" label="Reference" help="Reference spectrum (zipped Bruker NMR dataset)"/>


### PR DESCRIPTION
This is a tool from CERM to compare a reference spectrum to a newly acquired one.  I'd really like to get it into this release so here's the PR on the day of the deadline :-)

The implementation works, though the Galaxy integration is iffy (but I can fix it during our bug fixing phase).

In addition to the tool, this PR introduces the `bruker_zip` galaxy data type for a zip archived Bruker NMR output.  If uploaded the dataset is not extracted by Galaxy.