### PR TITLE
Changes galaxy branch to avoid 18.05 hybrid issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Clone galaxy into /galaxy directory
-RUN git clone --depth 1 --single-branch --branch release_18.01_plus_isa_runnerRestartJobs https://github.com/phnmnl/galaxy.git
+RUN git clone --depth 1 --single-branch --branch release_18.01_plus_isa_runnerRJ_clean https://github.com/phnmnl/galaxy.git
 WORKDIR /galaxy
 
 RUN echo "pykube==0.15.0" >> requirements.txt 

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -120,7 +120,7 @@ ANSIBLE_RELEASE=18.01-k8s
 GALAXY_BASE_FROM_TO_REPLACE=quay.io/bgruening/galaxy-base:18.01
 
 GALAXY_REPO=phnmnl/galaxy
-GALAXY_RELEASE=release_18.01_plus_isa_runnerRestartJobs
+GALAXY_RELEASE=release_18.01_plus_isa_runnerRJ_clean
 
 GALAXY_VER_FOR_POSTGRES=18.01
 


### PR DESCRIPTION
An unfortunate mixup in the phnmnl/galaxy repo meant that our Galaxy setup was dirty with 18.05 commits. This PR redirects our Galaxy cloning to a clean 18.01 (plus our desired commits for ISA and others).