### PR TITLE
Add a link to shared workflows page from welcome page

### DIFF
--- a/html/welcome.html
+++ b/html/welcome.html
@@ -89,14 +89,17 @@
                 <td>
                     <h2>Quickstart</h2>
                     <strong>New to Galaxy, start here!</strong><br />
-                    First time users can watch the example workflow tutorials on <a target="_blank" href="https://www.youtube.com/channel/UCXGAvsVNQk-aUpckjRC8Ang">YouTube</a> and run the example workflows with the instructions given in these tutorials:<br />
+                    First time users can watch the example workflow tutorials on <a target="_blank" href="https://www.youtube.com/channel/UCXGAvsVNQk-aUpckjRC8Ang">YouTube</a> and run the example workflows with the instructions given in these <strong>tutorials</strong>:<br />
                     <div class="buttons">
                         <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/fluxomics-workflow">Fluxomics</a>
                         <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/MS-MetFrag-XCMS-Workflow">LC-MS</a>
                         <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/NMR1d-Workflow">NMR</a>
                         <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/Sacurine-statistical-workflow">Statistics</a>
                     </div>
-		    You can also try our <a target="_blank" href="/tours">interactive tours</a>.
+
+                    You can access the <strong>sample workflows</strong> in <a href="/workflows/list_published" target="_parent">Galaxy's workflow list</a>.
+
+                    You can also try our <a target="_blank" href="/tours">interactive tours</a>.
 
                     <h2>Support</h2>
                     <ul>


### PR DESCRIPTION
Tries to address issue #199.  Note that the link is hard-coded and will break if our Galaxy installation is ever not configured to be at the server root URL.

