### PR TITLE
Clearly label buttons on landing page as pointing to "tutorials"

### DIFF
--- a/html/welcome.html
+++ b/html/welcome.html
@@ -91,10 +91,10 @@
                     <strong>New to Galaxy, start here!</strong><br />
                     First time users can watch the example workflow tutorials on <a target="_blank" href="https://www.youtube.com/channel/UCXGAvsVNQk-aUpckjRC8Ang">YouTube</a> and run the example workflows with the instructions given in these <strong>tutorials</strong>:<br />
                     <div class="buttons">
-                        <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/fluxomics-workflow">Fluxomics</a>
-                        <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/MS-MetFrag-XCMS-Workflow">LC-MS</a>
-                        <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/NMR1d-Workflow">NMR</a>
-                        <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/Sacurine-statistical-workflow">Statistics</a>
+                        <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/fluxomics-workflow">Fluxomics Tutorial</a>
+                        <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/MS-MetFrag-XCMS-Workflow">LC-MS Tutorial</a>
+                        <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/NMR1d-Workflow">NMR Tutorial</a>
+                        <a class="button-link" target="_blank" href="http://portal.phenomenal-h2020.eu/help/Sacurine-statistical-workflow">Statistics Tutorial</a>
                     </div>
 
                     You can access the <strong>sample workflows</strong> in <a href="/workflows/list_published" target="_parent">Galaxy's workflow list</a>.


### PR DESCRIPTION
Should solve issue #82