### PR TITLE
Hotfix/iso2flux & escher fluxomics (18.01)

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -223,7 +223,7 @@
     <tool id="fingerprint_clustering" destination="dynamic-k8s-medium" resources="all"/>
     <tool id="fingerprint_subnetwork" destination="dynamic-k8s-medium" resources="all"/>
     <!-- Fluxomics -->
-    <tool id="iso2flux" destination="dynamic-k8s-small" resources="all"/>     
+    <tool id="iso2flux" destination="dynamic-k8s-medium" resources="all"/>     
     <tool id="midcor" destination="dynamic-k8s-small" resources="all"/>
     <tool id="ramid" destination="dynamic-k8s-tiny" resources="all"/>
     <tool id="cdf2mid" destination="dynamic-k8s-tiny" resources="all"/>

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -36,7 +36,7 @@ assignment:
   docker_repo_override: container-registry.phenomenal-h2020.eu
   docker_owner_override: phnmnl
   docker_image_override: escher-fluxomics
-  docker_tag_override: dev_v1.6.0-beta.4_cv1.1.19 
+  docker_tag_override: v1.6.0-beta.4_cv1.1.20 
   max_pod_retrials: 3
 - tools_id:
    - iso2flux

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -36,14 +36,14 @@ assignment:
   docker_repo_override: container-registry.phenomenal-h2020.eu
   docker_owner_override: phnmnl
   docker_image_override: escher-fluxomics
-  docker_tag_override: v1.6.0-beta.4_cv1.0.9
+  docker_tag_override: dev_v1.6.0-beta.4_cv1.1.19 
   max_pod_retrials: 3
 - tools_id:
    - iso2flux
   docker_repo_override: container-registry.phenomenal-h2020.eu
   docker_owner_override: phnmnl
   docker_image_override: iso2flux
-  docker_tag_override: v0.7_cv2.1.52          
+  docker_tag_override: dev_v0.7.1_cv2.1.58          
   max_pod_retrials: 3
 - tools_id:
    - midcor

--- a/config/phenomenal_tools2container.yaml
+++ b/config/phenomenal_tools2container.yaml
@@ -43,7 +43,7 @@ assignment:
   docker_repo_override: container-registry.phenomenal-h2020.eu
   docker_owner_override: phnmnl
   docker_image_override: iso2flux
-  docker_tag_override: dev_v0.7.1_cv2.1.58          
+  docker_tag_override: v0.7.1_cv2.1.60         
   max_pod_retrials: 3
 - tools_id:
    - midcor


### PR DESCRIPTION
-In phenomenal_tools2container.yaml: 
    -Updated Iso2flux container to v0.7.1_cv2.1.60 (minor bug fixes compared to previous build)  
    -Updated Escher Fluxomics container to dev_v1.6.0-beta.4_cv1.1.19  (version compatible with   Iso2flux 0.7 and newer). v1.6.0-beta.4_cv1.1.20 also ought to work but we have not test it.
-In job_conf.xml: Changed Iso2flux resource profile from small to medium 

The changes have been tested in a local Galaxy Instance and appear to work with no apparent issue