### PR TITLE
Add maintenance build option to build script

### DIFF
--- a/Dockerfile_init
+++ b/Dockerfile_init
@@ -1,26 +1,15 @@
-FROM pcm32/galaxy-init-pheno
+FROM container-registry.phenomenal-h2020.eu/phnmnl/galaxy-init-pheno-flavoured:dev_v18.01-pheno-isa_cv1.7.301
 
 MAINTAINER PhenoMeNal-H2020 Project <phenomenal-h2020-users@googlegroups.com>
 
 LABEL Description="Galaxy 18.01-pheno-dev for running inside Kubernetes."
 LABEL software="Galaxy Init"
 LABEL software.version="18.01-pheno-dev"
-LABEL version="1.6"
+LABEL version="1.7"
 
 # Patch for up to 18.05-dev only, not tested on 19.01 and should not be used >= 19.05
 # Avoids failure due to missing errored job in k8s (line 499)
 COPY patches/kubernetes.py /galaxy-export/galaxy-central/lib/galaxy/jobs/runners/kubernetes.py
-
-RUN wget -O ephemeris.tar https://api.github.com/repos/galaxyproject/ephemeris/tarball/eeee87a57379b8b639b06c2a50038ef449c28d73 && \
-    tar -xf ephemeris.tar && rm ephemeris.tar && \
-    virtualenv venv-workflow && \
-    /bin/bash -c "source venv-workflow/bin/activate && \
-                  pip install 'pip>=8.1' && \
-                  pip install ./galaxyproject-ephemeris-eeee87a \
-                      --index-url https://pypi.python.org/simple && \
-                  pip install urllib3[secure] && \
-                  deactivate && \
-                  virtualenv --relocatable venv-workflow"
 
 #COPY config/galaxy.ini config/galaxy.ini
 COPY config/job_conf.xml config/job_conf.xml

--- a/simplified_galaxy_stable_container_creation.sh
+++ b/simplified_galaxy_stable_container_creation.sh
@@ -18,13 +18,13 @@ function log() {
 
 function error {
 
-	local msg=$1
-	local code=$2
-	[[ -z $code ]] && code=1
+    local msg=$1
+    local code=$2
+    [[ -z $code ]] && code=1
 
-	log "[ERROR] $msg"
+    log "[ERROR] $msg"
 
-	exit $code
+    exit $code
 }
 
 
@@ -63,6 +63,7 @@ function print_help {
         echo "       --web-tag        <tag>     Set the tag for the Galaxy Web k8s container image."
         echo "   -u, --container-user <user>    Set the container user. You can also set the environment variable CONTAINER_USER. [pcm32]"
         echo "   -r, --container-registry <reg> Set the container registry. You can also set the environment variable CONTAINER_REGISTRY."
+        echo "       --maintenance-build        Build in maintence mode (build only init image from Dockerfile_init in repository)."
         echo
     ) >&2
 }
@@ -87,6 +88,7 @@ function read_args {
             --web-tag)               OVERRIDE_GALAXY_WEB_K8S_TAG="$2" ; shift_count=2 ;;
             -u|--container-user)     CONTAINER_USER="$2" ; shift_count=2 ;;
             -r|--container-registry) CONTAINER_REGISTRY="$2" ; shift_count=2 ;;
+            --maintenance-build)     MAINTENANCE_BUILD=$TRUE ;;
             *) error "Illegal option $1." 98 ;;
         esac
         shift $shift_count
@@ -101,160 +103,185 @@ function read_args {
     debug "Argument OVERRIDE_GALAXY_WEB_K8S_TAG=$OVERRIDE_GALAXY_WEB_K8S_TAG"
     debug "Argument OVERRIDE_POSTGRES_TAG=$OVERRIDE_POSTGRES_TAG"
     debug "Argument OVERRIDE_PROFTPD_TAG=$OVERRIDE_PROFTPD_TAG"
+    debug "Argument MAINTENANCE_BUILD=$MAINTENANCE_BUILD"
     debug "shift_count=$shift_count"
 }
 
+function run_maintenance_build() {
+    docker build $NO_CACHE -t $GALAXY_INIT_PHENO_FLAVOURED_TAG -f $DOCKERFILE_INIT_FLAVOUR .
+
+    if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
+      docker push $GALAXY_INIT_PHENO_FLAVOURED_TAG
+    fi
+
+    log "Relevant containers:"
+    echo "Init Flavour: $GALAXY_INIT_PHENO_FLAVOURED_TAG"
+
+    log "Web, Postgres and Proftpd containers were not updated.  Use the previous ones."
+}
+
+function run_standard_build() {
+
+    if [ -n $ANSIBLE_REPO ]
+        then
+           log "Making custom galaxy-base-pheno:$TAG from $ANSIBLE_REPO at $ANSIBLE_RELEASE"
+           docker build $NO_CACHE --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t $GALAXY_BASE_PHENO_TAG docker-galaxy-stable/compose/galaxy-base/
+           if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES:-} ]];
+           then
+             log "Pushing intermediate image $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG"
+               docker push $GALAXY_BASE_PHENO_TAG
+           fi
+    fi
+
+
+    if [ -n $GALAXY_REPO ]
+        then
+           log "Making custom galaxy-init-pheno:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
+           DOCKERFILE_INIT_1=Dockerfile
+           if [ -n $ANSIBLE_REPO ]
+           then
+               sed s+$GALAXY_BASE_FROM_TO_REPLACE+$GALAXY_BASE_PHENO_TAG+ docker-galaxy-stable/compose/galaxy-init/Dockerfile > docker-galaxy-stable/compose/galaxy-init/Dockerfile_init
+               FROM=$(grep ^FROM docker-galaxy-stable/compose/galaxy-init/Dockerfile_init | awk '{ print $2 }')
+               log "Using FROM $FROM for galaxy init"
+               DOCKERFILE_INIT_1=Dockerfile_init
+           fi
+           docker build $NO_CACHE --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE --build-arg ISATOOLS_LITE_INSTALL=True -t $GALAXY_INIT_PHENO_TAG -f docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 docker-galaxy-stable/compose/galaxy-init/
+           if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES:-} ]];
+           then
+               log "Pushing intermediate image $GALAXY_INIT_PHENO_TAG"
+               docker push $GALAXY_INIT_PHENO_TAG
+           fi
+    fi
+
+
+    if [ -n $GALAXY_REPO ]
+    then
+      log "Making custom galaxy-init-pheno-flavoured:$TAG starting from galaxy-init-pheno:$TAG"
+      sed s+pcm32/galaxy-init-pheno$+$GALAXY_INIT_PHENO_TAG+ $DOCKERFILE_INIT_FLAVOUR > Dockerfile_init_tagged
+      DOCKERFILE_INIT_FLAVOUR=Dockerfile_init_tagged
+    fi
+    docker build $NO_CACHE -t $GALAXY_INIT_PHENO_FLAVOURED_TAG -f $DOCKERFILE_INIT_FLAVOUR .
+
+    if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
+      docker push $GALAXY_INIT_PHENO_FLAVOURED_TAG
+    fi
+
+
+    if [ -n $GALAXY_REPO ]
+    then
+      log "Making custom galaxy-web-k8s:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
+      sed s+$GALAXY_BASE_FROM_TO_REPLACE+$GALAXY_BASE_PHENO_TAG+ docker-galaxy-stable/compose/galaxy-web/Dockerfile > docker-galaxy-stable/compose/galaxy-web/Dockerfile_web
+      DOCKERFILE_WEB=Dockerfile_web
+    fi
+    docker build $NO_CACHE --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8,k8s -t $GALAXY_WEB_K8S_TAG -f docker-galaxy-stable/compose/galaxy-web/$DOCKERFILE_WEB docker-galaxy-stable/compose/galaxy-web/
+
+    if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
+      docker push $GALAXY_WEB_K8S_TAG
+    fi
+
+    # Build postgres
+    docker build -t $POSTGRES_TAG -f docker-galaxy-stable/compose/galaxy-postgres/Dockerfile docker-galaxy-stable/compose/galaxy-postgres/
+
+    if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
+      docker push $POSTGRES_TAG
+    fi
+
+    # Build proftpd
+    docker build -t $PROFTPD_TAG -f docker-galaxy-stable/compose/galaxy-proftpd/Dockerfile docker-galaxy-stable/compose/galaxy-proftpd/
+
+    if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
+      docker push $PROFTPD_TAG
+    fi
+
+    log "Relevant containers:"
+    echo "Web:          $GALAXY_WEB_K8S_TAG"
+    echo "Init Flavour: $GALAXY_INIT_PHENO_FLAVOURED_TAG"
+    echo "Postgres:     $POSTGRES_TAG"
+    echo "Proftpd:      $PROFTPD_TAG"
+}
+
+function main() {
+    read_args "$@"
+
+
+    DOCKER_PUSH_ENABLED=${DOCKER_PUSH_ENABLED:-$DFT_DOCKER_PUSH_ENABLED}
+
+    DOCKER_REPO=${CONTAINER_REGISTRY:-}
+    DOCKER_USER=${CONTAINER_USER:-pcm32}
+
+    ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
+    ANSIBLE_RELEASE=18.01-k8s
+
+    GALAXY_BASE_FROM_TO_REPLACE=quay.io/bgruening/galaxy-base:18.01
+
+    GALAXY_REPO=phnmnl/galaxy
+    GALAXY_RELEASE=release_18.01_plus_isa_runnerRJ_clean
+
+    GALAXY_VER_FOR_POSTGRES=18.01
+
+    # Default tag.  Note that this is overridden if CONTAINER_TAG_PREFIX and BUILD_NUMBER are set
+    TAG=v18.01-pheno-dev
+
+    if [[ -n ${CONTAINER_TAG_PREFIX:-} && -n ${BUILD_NUMBER:-} ]]; then
+        TAG=${CONTAINER_TAG_PREFIX}.${BUILD_NUMBER}
+    fi
+
+    DOCKERFILE_INIT_FLAVOUR=Dockerfile_init
+    DOCKERFILE_WEB=Dockerfile
+
+    if [[ -n "${DOCKER_REPO}" ]]; then
+        # Append slash, avoiding double slash
+        DOCKER_REPO="${DOCKER_REPO%/}/"
+    fi
+
+    GALAXY_BASE_PHENO_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG
+    GALAXY_INIT_PHENO_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG
+
+
+    ### Set tags ###
+    if [[ -n "${OVERRIDE_GALAXY_INIT_PHENO_FLAVOURED_TAG:-}" ]]; then
+        GALAXY_INIT_PHENO_FLAVOURED_TAG="${OVERRIDE_GALAXY_INIT_PHENO_FLAVOURED_TAG}"
+    else
+        GALAXY_INIT_PHENO_FLAVOURED_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init-pheno-flavoured:$TAG
+    fi
+
+    if [[ -n "${OVERRIDE_GALAXY_WEB_K8S_TAG:-}" ]]; then
+        GALAXY_WEB_K8S_TAG="${OVERRIDE_GALAXY_WEB_K8S_TAG}"
+    else
+        GALAXY_WEB_K8S_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG
+    fi
+
+    if [[ -n "${OVERRIDE_POSTGRES_TAG:-}" ]]; then
+        POSTGRES_TAG="${OVERRIDE_POSTGRES_TAG}"
+    else
+        PG_Dockerfile="docker-galaxy-stable/compose/galaxy-postgres/Dockerfile"
+
+        [[ -f "${PG_Dockerfile}" ]] || error "The galaxy-postgres Dockerfile is missing under docker-galaxy-stable/.  Have you updated the repository submodules?" 99
+        POSTGRES_VERSION=$(grep FROM "${PG_Dockerfile}" | awk -F":" '{ print $2 }')
+
+        POSTGRES_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-postgres:$POSTGRES_VERSION"_for_"$GALAXY_VER_FOR_POSTGRES
+    fi
+
+
+    if [[ -n "${OVERRIDE_PROFTPD_TAG:-}" ]]; then
+        PROFTPD_TAG="${OVERRIDE_PROFTPD_TAG}"
+    else
+        PROFTPD_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-proftpd:for_galaxy_v$GALAXY_VER_FOR_POSTGRES
+    fi
+
+
+    if [[ -n "${MAINTENANCE_BUILD:-}" ]]; then
+        run_maintenance_build
+    else
+        run_standard_build
+    fi
+
+    if [[ "${DOCKER_PUSH_ENABLED:-}" != "true" ]]; then
+      log "Container images not pushed.  They are only available in your current Docker daemon"
+    fi
+}
+
 ### MAIN ###
-
-read_args "$@"
-
-
-DOCKER_PUSH_ENABLED=${DOCKER_PUSH_ENABLED:-$DFT_DOCKER_PUSH_ENABLED}
-
-DOCKER_REPO=${CONTAINER_REGISTRY:-}
-DOCKER_USER=${CONTAINER_USER:-pcm32}
-
-ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
-ANSIBLE_RELEASE=18.01-k8s
-
-GALAXY_BASE_FROM_TO_REPLACE=quay.io/bgruening/galaxy-base:18.01
-
-GALAXY_REPO=phnmnl/galaxy
-GALAXY_RELEASE=release_18.01_plus_isa_runnerRJ_clean
-
-GALAXY_VER_FOR_POSTGRES=18.01
-
-# Default tag.  Note that this is overridden if CONTAINER_TAG_PREFIX and BUILD_NUMBER are set
-TAG=v18.01-pheno-dev
-
-if [[ -n ${CONTAINER_TAG_PREFIX:-} && -n ${BUILD_NUMBER:-} ]]; then
-    TAG=${CONTAINER_TAG_PREFIX}.${BUILD_NUMBER}
-fi
-
-DOCKERFILE_INIT_FLAVOUR=Dockerfile_init
-DOCKERFILE_WEB=Dockerfile
-
-if [[ -n "${DOCKER_REPO}" ]]; then
-    # Append slash, avoiding double slash
-    DOCKER_REPO="${DOCKER_REPO%/}/"
-fi
-
-GALAXY_BASE_PHENO_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG
-GALAXY_INIT_PHENO_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init-pheno:$TAG
-
-
-### Set tags ###
-if [[ -n "${OVERRIDE_GALAXY_INIT_PHENO_FLAVOURED_TAG:-}" ]]; then
-    GALAXY_INIT_PHENO_FLAVOURED_TAG="${OVERRIDE_GALAXY_INIT_PHENO_FLAVOURED_TAG}"
-else
-    GALAXY_INIT_PHENO_FLAVOURED_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init-pheno-flavoured:$TAG
-fi
-
-if [[ -n "${OVERRIDE_GALAXY_WEB_K8S_TAG:-}" ]]; then
-    GALAXY_WEB_K8S_TAG="${OVERRIDE_GALAXY_WEB_K8S_TAG}"
-else
-    GALAXY_WEB_K8S_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG
-fi
-
-if [[ -n "${OVERRIDE_POSTGRES_TAG:-}" ]]; then
-    POSTGRES_TAG="${OVERRIDE_POSTGRES_TAG}"
-else
-    PG_Dockerfile="docker-galaxy-stable/compose/galaxy-postgres/Dockerfile"
-
-    [[ -f "${PG_Dockerfile}" ]] || error "The galaxy-postgres Dockerfile is missing under docker-galaxy-stable/.  Have you updated the repository submodules?" 99
-    POSTGRES_VERSION=$(grep FROM "${PG_Dockerfile}" | awk -F":" '{ print $2 }')
-
-    POSTGRES_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-postgres:$POSTGRES_VERSION"_for_"$GALAXY_VER_FOR_POSTGRES
-fi
-
-
-if [[ -n "${OVERRIDE_PROFTPD_TAG:-}" ]]; then
-    PROFTPD_TAG="${OVERRIDE_PROFTPD_TAG}"
-else
-    PROFTPD_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-proftpd:for_galaxy_v$GALAXY_VER_FOR_POSTGRES
-fi
-
-
-### do work
-
-if [ -n $ANSIBLE_REPO ]
-    then
-       log "Making custom galaxy-base-pheno:$TAG from $ANSIBLE_REPO at $ANSIBLE_RELEASE"
-       docker build $NO_CACHE --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t $GALAXY_BASE_PHENO_TAG docker-galaxy-stable/compose/galaxy-base/
-       if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES:-} ]];
-       then
-         log "Pushing intermediate image $DOCKER_REPO$DOCKER_USER/galaxy-base-pheno:$TAG"
-           docker push $GALAXY_BASE_PHENO_TAG
-       fi
-fi
-
-
-if [ -n $GALAXY_REPO ]
-    then
-       log "Making custom galaxy-init-pheno:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
-       DOCKERFILE_INIT_1=Dockerfile
-       if [ -n $ANSIBLE_REPO ]
-       then
-           sed s+$GALAXY_BASE_FROM_TO_REPLACE+$GALAXY_BASE_PHENO_TAG+ docker-galaxy-stable/compose/galaxy-init/Dockerfile > docker-galaxy-stable/compose/galaxy-init/Dockerfile_init
-           FROM=$(grep ^FROM docker-galaxy-stable/compose/galaxy-init/Dockerfile_init | awk '{ print $2 }')
-           log "Using FROM $FROM for galaxy init"
-           DOCKERFILE_INIT_1=Dockerfile_init
-       fi
-       docker build $NO_CACHE --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE --build-arg ISATOOLS_LITE_INSTALL=True -t $GALAXY_INIT_PHENO_TAG -f docker-galaxy-stable/compose/galaxy-init/$DOCKERFILE_INIT_1 docker-galaxy-stable/compose/galaxy-init/
-       if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES:-} ]];
-       then
-           log "Pushing intermediate image $GALAXY_INIT_PHENO_TAG"
-           docker push $GALAXY_INIT_PHENO_TAG
-       fi
-fi
-
-
-if [ -n $GALAXY_REPO ]
-then
-  log "Making custom galaxy-init-pheno-flavoured:$TAG starting from galaxy-init-pheno:$TAG"
-  sed s+pcm32/galaxy-init-pheno$+$GALAXY_INIT_PHENO_TAG+ $DOCKERFILE_INIT_FLAVOUR > Dockerfile_init_tagged
-  DOCKERFILE_INIT_FLAVOUR=Dockerfile_init_tagged
-fi
-docker build $NO_CACHE -t $GALAXY_INIT_PHENO_FLAVOURED_TAG -f $DOCKERFILE_INIT_FLAVOUR .
-
-if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
-  docker push $GALAXY_INIT_PHENO_FLAVOURED_TAG
-fi
-
-
-if [ -n $GALAXY_REPO ]
-then
-  log "Making custom galaxy-web-k8s:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
-  sed s+$GALAXY_BASE_FROM_TO_REPLACE+$GALAXY_BASE_PHENO_TAG+ docker-galaxy-stable/compose/galaxy-web/Dockerfile > docker-galaxy-stable/compose/galaxy-web/Dockerfile_web
-  DOCKERFILE_WEB=Dockerfile_web
-fi
-docker build $NO_CACHE --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8,k8s -t $GALAXY_WEB_K8S_TAG -f docker-galaxy-stable/compose/galaxy-web/$DOCKERFILE_WEB docker-galaxy-stable/compose/galaxy-web/
-
-if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
-  docker push $GALAXY_WEB_K8S_TAG
-fi
-
-# Build postgres
-docker build -t $POSTGRES_TAG -f docker-galaxy-stable/compose/galaxy-postgres/Dockerfile docker-galaxy-stable/compose/galaxy-postgres/
-
-if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
-  docker push $POSTGRES_TAG
-fi
-
-# Build proftpd
-docker build -t $PROFTPD_TAG -f docker-galaxy-stable/compose/galaxy-proftpd/Dockerfile docker-galaxy-stable/compose/galaxy-proftpd/
-
-if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
-  docker push $PROFTPD_TAG
-fi
-
-
-log "Relevant containers:"
-echo "Web:          $GALAXY_WEB_K8S_TAG"
-echo "Init Flavour: $GALAXY_INIT_PHENO_FLAVOURED_TAG"
-echo "Postgres:     $POSTGRES_TAG"
-echo "Proftpd:      $PROFTPD_TAG"
-
-if [[ "${DOCKER_PUSH_ENABLED:-}" != "true" ]]; then
-  log "Container images not pushed.  They are only available in your current Docker daemon"
+if [[ "${BASH_SOURCE}" == "${0}" ]]; then
+    main "${@}"
 fi


### PR DESCRIPTION
This PR adds a `--maintenance-build` option to the build script that:
1. only builds the init image
2. bases the image on the last working build available at the time of this PR.

Building from scratch no longer works due to some dependency having been updated in an incompatible way.  This change, which is being used by our Jenkins build, allows us to add changes to the PhenoMeNal installation without trying to adapt it to upstream changes.